### PR TITLE
Updated Marker API Endpoint for YR

### DIFF
--- a/apps/site/api/serializers/__init__.py
+++ b/apps/site/api/serializers/__init__.py
@@ -7,7 +7,7 @@ from localground.apps.site import models
 from localground.apps.site.api.serializers.base_serializer import BaseSerializer, BaseNamedSerializer, MediaGeometrySerializer
 from localground.apps.site.api.serializers.project_serializer import ProjectSerializer, ProjectDetailSerializer
 from localground.apps.site.api.serializers.snapshot_serializer import SnapshotSerializer, SnapshotDetailSerializer
-from localground.apps.site.api.serializers.marker_serializer import MarkerSerializer, MarkerSerializerCounts, MarkerSerializerLists
+from localground.apps.site.api.serializers.marker_serializer import MarkerSerializer, MarkerSerializerCounts, MarkerSerializerCountsWithMetadata, MarkerSerializerLists, MarkerSerializerListsWithMetadata
 from localground.apps.site.api.serializers.association_serializer import AssociationSerializer, AssociationSerializerDetail
 from localground.apps.site.api.serializers.photo_serializer import PhotoSerializer
 from localground.apps.site.api.serializers.audio_serializer import AudioSerializer

--- a/apps/site/api/serializers/base_serializer.py
+++ b/apps/site/api/serializers/base_serializer.py
@@ -54,7 +54,7 @@ class GeometrySerializer(BaseNamedSerializer):
         help_text='Assign a GeoJSON string',
         required=False,
         allow_null=True,
-        style={'base_template': 'textarea.html'},
+        style={'base_template': 'json.html'},
         source='point'
     )
     project_id = serializers.PrimaryKeyRelatedField(
@@ -91,9 +91,7 @@ class ExtentsSerializer(BaseNamedSerializer):
     center = fields.GeometryField(
                         help_text='Assign a GeoJSON string',
                         required=False,
-                        style={'base_template:input.html'},
-                        #widget=widgets.JSONWidget,
-                        #point_field_name='center'
+                        style={'base_template:json.html'}
                     )
 
 

--- a/apps/site/api/serializers/layer_serializer.py
+++ b/apps/site/api/serializers/layer_serializer.py
@@ -6,7 +6,7 @@ from localground.apps.site.api import fields
 
 class LayerSerializer(BaseNamedSerializer):
     access = serializers.SerializerMethodField()
-    symbols = fields.JSONField(style={'base_template': 'textarea.html'},
+    symbols = fields.JSONField(style={'base_template': 'json.html'},
                                required=False)
 
     class Meta:

--- a/apps/site/api/serializers/marker_serializer.py
+++ b/apps/site/api/serializers/marker_serializer.py
@@ -173,12 +173,6 @@ class MarkerSerializerCounts(MarkerSerializerMixin):
     audio_count = serializers.SerializerMethodField()
     map_image_count = serializers.SerializerMethodField()
     record_count = serializers.SerializerMethodField()
-    
-    def __init__(self, *args, **kwargs):
-        super(MarkerSerializerCounts, self).__init__(*args, **kwargs)
-        r = self.context.get('request') 
-        if r and r.GET.get('include_metadata') in ['True', 'true', '1']:
-            self.Meta.fields += ('update_metadata',)
 
     class Meta:
         model = models.Marker
@@ -209,18 +203,18 @@ class MarkerSerializerCounts(MarkerSerializerMixin):
             return obj.record_count
         except:
             return None
+        
+class MarkerSerializerCountsWithMetadata(MarkerSerializerCounts):
+    class Meta:
+        model = models.Marker
+        fields = MarkerSerializerCounts.Meta.fields + ('update_metadata', )
+        depth = 0
     
 class MarkerSerializerLists(MarkerSerializerMixin):
     photo_array = serializers.SerializerMethodField()
     audio_array = serializers.SerializerMethodField()
     map_image_array = serializers.SerializerMethodField()
     record_array = serializers.SerializerMethodField()
-    
-    def __init__(self, *args, **kwargs):
-        super(MarkerSerializerLists, self).__init__(*args, **kwargs)
-        r = self.context.get('request') 
-        if r and r.GET.get('include_metadata') in ['True', 'true', '1']:
-            self.Meta.fields += ('update_metadata',)
 
     class Meta:
         model = models.Marker
@@ -251,3 +245,9 @@ class MarkerSerializerLists(MarkerSerializerMixin):
             return obj.record_array
         except:
             return None
+        
+class MarkerSerializerListsWithMetadata(MarkerSerializerLists):
+    class Meta:
+        model = models.Marker
+        fields = MarkerSerializerLists.Meta.fields + ('update_metadata', )
+        depth = 0

--- a/apps/site/api/serializers/presentation_serializer.py
+++ b/apps/site/api/serializers/presentation_serializer.py
@@ -12,7 +12,7 @@ class PresentationSerializer(BaseNamedSerializer):
     '''
     code = fields.JSONField(
         #widget=widgets.JSONWidget,
-        style={'base_template': 'textarea.html'},
+        style={'base_template': 'json.html'},
         required=False)
 
     class Meta:

--- a/apps/site/api/serializers/print_serializer.py
+++ b/apps/site/api/serializers/print_serializer.py
@@ -43,7 +43,7 @@ class PrintSerializerMixin(serializers.ModelSerializer):
     overlay_type = serializers.SerializerMethodField()
     center = fields.GeometryField(
                 help_text='Assign a GeoJSON center point',
-                style={'base_template': 'textarea.html'},
+                style={'base_template': 'json.html'},
                 required=True
             )
     
@@ -99,7 +99,7 @@ class PrintSerializer(ExtentsSerializer, PrintSerializerMixin):
 class PrintSerializerDetail(ExtentsSerializer, PrintSerializerMixin):
     center = fields.GeometryField(
                 help_text='Assign a GeoJSON center point',
-                style={'base_template': 'textarea.html'},
+                style={'base_template': 'json.html'},
                 read_only=True
             )
     layout = serializers.SerializerMethodField()

--- a/apps/site/api/serializers/record_serializer.py
+++ b/apps/site/api/serializers/record_serializer.py
@@ -11,7 +11,7 @@ class BaseRecordSerializer(serializers.ModelSerializer):
         help_text='Assign a GeoJSON string',
         required=False,
         allow_null=True,
-        style={'base_template': 'textarea.html'},
+        style={'base_template': 'json.html'},
         source='point'
     )
     project_id = serializers.PrimaryKeyRelatedField(

--- a/apps/site/api/serializers/snapshot_serializer.py
+++ b/apps/site/api/serializers/snapshot_serializer.py
@@ -18,12 +18,12 @@ class SnapshotSerializer(BaseNamedSerializer):
         validators=[ validators.UniqueValidator(models.Snapshot.objects.all()) ]
     )
     entities = fields.EntitiesField(
-        style={'base_template': 'textarea.html'},
+        style={'base_template': 'json.html'},
         required=False)
     center = fields.GeometryField(
                 help_text='Assign a GeoJSON string',
                 required=True,
-                style={'base_template': 'textarea.html'}
+                style={'base_template': 'json.html'}
             )
     basemap = serializers.PrimaryKeyRelatedField(queryset=models.WMSOverlay.objects.all())
     zoom = serializers.IntegerField(min_value=1, max_value=20, default=17)
@@ -130,7 +130,8 @@ class SnapshotSerializer(BaseNamedSerializer):
             'data': serializer.data
         }
         try:
-            if self.request.GET.get("include_schema") in ['True', 'true', '1']:
+            r = self.context.get('request') 
+            if r and r.GET.get('include_metadata') in ['True', 'true', '1']:
                 d.update({
                     'update_metadata': serializer.metadata() #,
                     #'create_metadata': serializer_class().metadata()

--- a/apps/site/api/tests/marker_tests.py
+++ b/apps/site/api/tests/marker_tests.py
@@ -10,22 +10,23 @@ from django.contrib.gis.geos import GEOSGeometry
 def get_metadata():
     return {
         'photo_count': {'read_only': True, 'required': False, 'type': 'field'},
+        'audio_count': {'read_only': True, 'required': False, 'type': 'field'},
+        'map_image_count': {'read_only': True, 'required': False, 'type': 'field'},
+        'record_count': {'read_only': True, 'required': False, 'type': 'field'},
         'description': {'read_only': False, 'required': False, 'type': 'memo'},
         'tags': {'read_only': False, 'required': False, 'type': 'string'},
         'url': {'read_only': True, 'required': False, 'type': 'field'},
-        'audio_count': {'read_only': True, 'required': False, 'type': 'field'},
         'overlay_type': {'read_only': True, 'required': False, 'type': 'field'},
-        'map_image_count': {'read_only': True, 'required': False, 'type': 'field'},
         'geometry': {'read_only': False, 'required': False, 'type': 'geojson'},
-        'record_count': {'read_only': True, 'required': False, 'type': 'field'},
         'owner': {'read_only': True, 'required': False, 'type': 'field'},
         'project_id': {'read_only': False, 'required': False, 'type': 'field'},
         'id': {'read_only': True, 'required': False, 'type': 'integer'},
         'color': {'read_only': False, 'required': False, 'type': 'color'},
-        'name': {'read_only': False, 'required': False, 'type': 'string'}
+        'name': {'read_only': False, 'required': False, 'type': 'string'},
+        'extras': {'read_only': False, 'required': False, 'type': 'json'}
     }
 
-class GeomMixin(object):
+class DataMixin(object):
     Point = {
         "type": "Point",
         "coordinates": [12.492324113849, 41.890307434153]
@@ -49,34 +50,69 @@ class GeomMixin(object):
         "coordinates": [[[100.0, 0.0, 6, 8], [101.0, 0.0], [101.0, 1.0],
                          [100.0, 1.0], [100.0, 0.0]]]
     }
+    ExtrasGood = '''{
+        "source": "http://google.com",
+        "video": "youtube.com",
+        "order": 5
+    }'''
+    ExtrasBad = '''{
+        "source": "http://google.com",
+        "video",
+        "order": 5
+    }'''
 
 
-class ApiMarkerListTest(test.TestCase, ViewMixinAPI, GeomMixin):
+class ApiMarkerListTest(test.TestCase, ViewMixinAPI, DataMixin):
 
     def setUp(self):
         ViewMixinAPI.setUp(self)
         self.urls = ['/api/0/markers/']
         self.view = views.MarkerList.as_view()
         self.metadata = get_metadata()
-        self.metadata.update({
-            'update_metadata': {'read_only': True, 'required': False, 'type': 'field'}
-        })
+        self.marker = self.create_marker(self.user, self.project)
+    
+    def test_metadata_only_available_with_flag(self, **kwargs):
+        response = self.client_user.get(self.urls[0])
+        m = response.data.get("results")[0]
+        self.assertIsNone(m.get("update_metadata"))
+        
+        response = self.client_user.get(self.urls[0], {'include_metadata': True})
+        m = response.data.get("results")[0]
+        self.assertIsNotNone(m.get("update_metadata"))
+        
+    def test_arrays_available_when_flag_exists(self):
+        #create some associations:
+        self.photo1 = self.create_photo(self.user, self.project)
+        self.audio1 = self.create_audio(self.user, self.project)
+        self.create_relation(models.Photo.get_content_type(), id=self.photo1.id, ordering=1)
+        self.create_relation(models.Audio.get_content_type(), id=self.audio1.id, ordering=1)
+        response = self.client_user.get(
+            self.urls[0], {'marker_with_media_arrays': True}
+        )
+        marker = response.data.get("results")[0]
+        self.assertEqual(len(marker.get('photo_array')), 1)
+        self.assertEqual(len(marker.get('audio_array')), 1)
+        self.assertTrue('record_array' in marker)
+        self.assertTrue('map_image_array' in marker)
         
 
-    def test_bad_json_create_fails(self, **kwargs):
-        for k in ['Crazy1', 'Crazy2']:
-            geom = getattr(self, k)
+    def test_bad_json_creates_fails(self, **kwargs):
+        # 1. define a series of bad JSON dictionaries
+        for d in [{'geometry': self.Crazy1}, {'geometry': self.Crazy2}, {'extras': self.ExtrasBad}]:
+            params = {
+                'name': 'New Marker Name',
+                'description': 'Test description',
+                'color': 'FF0000',
+                'geometry': self.Point,
+                'project_id': self.project.id,
+                'extras': self.ExtrasGood
+            }
+            # 2. update the params dictionary with the invalid dictionary entry.
+            params.update(d)
             for i, url in enumerate(self.urls):
-                name, description, color = 'New Marker Name', \
-                    'Test description', 'FF0000'
                 response = self.client_user.post(
                     url,
-                    data=urllib.urlencode(
-                        {
-                            'geometry': geom,
-                            'name': name,
-                            'description': description,
-                            'color': color}),
+                    data=urllib.urlencode(params),
                     HTTP_X_CSRFTOKEN=self.csrf_token,
                     content_type="application/x-www-form-urlencoded")
                 self.assertEqual(
@@ -95,7 +131,8 @@ class ApiMarkerListTest(test.TestCase, ViewMixinAPI, GeomMixin):
                         'name': name,
                         'description': description,
                         'color': color,
-                        'project_id': self.project.id
+                        'project_id': self.project.id,
+                        'extras': self.ExtrasGood
                     }),
                     HTTP_X_CSRFTOKEN=self.csrf_token,
                     content_type="application/x-www-form-urlencoded")
@@ -112,9 +149,10 @@ class ApiMarkerListTest(test.TestCase, ViewMixinAPI, GeomMixin):
                         json.dumps(geom)))
                 self.assertEqual(k, new_marker.geometry.geom_type)
                 self.assertEqual(new_marker.project.id, self.project.id)
+                self.assertEqual(new_marker.extras, json.loads(self.ExtrasGood))
 
 
-class ApiMarkerInstanceTest(test.TestCase, ViewMixinAPI, GeomMixin):
+class ApiMarkerInstanceTest(test.TestCase, ViewMixinAPI, DataMixin):
 
     def setUp(self):
         ViewMixinAPI.setUp(self, load_fixtures=True)
@@ -128,19 +166,21 @@ class ApiMarkerInstanceTest(test.TestCase, ViewMixinAPI, GeomMixin):
         })
 
     def test_bad_json_update_fails(self, **kwargs):
-        for k in ['Crazy1', 'Crazy2']:
-            geom = getattr(self, k)
+        # 1. define a series of bad JSON dictionaries
+        for d in [{'geometry': self.Crazy1}, {'geometry': self.Crazy2}, {'extras': self.ExtrasBad}]:
+            params = {
+                'name': 'New Marker Name',
+                'description': 'Test description',
+                'color': 'FF0000',
+                'geometry': self.Point,
+                'extras': self.ExtrasGood
+            }
+            # 2. update the params dictionary with the invalid dictionary entry.
+            params.update(d)
             for i, url in enumerate(self.urls):
-                name, description, color = 'New Marker Name', \
-                    'Test description', 'FF0000'
                 response = self.client_user.put(
                     url,
-                    data=urllib.urlencode(
-                        {
-                            'geometry': geom,
-                            'name': name,
-                            'description': description,
-                            'color': color}),
+                    data=urllib.urlencode(params),
                     HTTP_X_CSRFTOKEN=self.csrf_token,
                     content_type="application/x-www-form-urlencoded")
                 self.assertEqual(
@@ -155,16 +195,18 @@ class ApiMarkerInstanceTest(test.TestCase, ViewMixinAPI, GeomMixin):
                     'Test description', 'FF0000'
                 response = self.client_user.put(
                     url,
-                    data=urllib.urlencode(
-                        {
-                            'geometry': geom,
-                            'name': name,
-                            'description': description,
-                            'color': color}),
+                    data=urllib.urlencode({
+                        'geometry': geom,
+                        'name': name,
+                        'description': description,
+                        'color': color,
+                        'extras': self.ExtrasGood
+                    }),
                     HTTP_X_CSRFTOKEN=self.csrf_token,
                     content_type="application/x-www-form-urlencoded")
                 self.assertEqual(response.status_code, status.HTTP_200_OK)
                 updated_marker = models.Marker.objects.get(id=self.marker.id)
+                result_json = response.data
                 self.assertEqual(updated_marker.name, name)
                 self.assertEqual(updated_marker.description, description)
                 self.assertEqual(updated_marker.color, color)
@@ -172,6 +214,11 @@ class ApiMarkerInstanceTest(test.TestCase, ViewMixinAPI, GeomMixin):
                     updated_marker.geometry,
                     GEOSGeometry(
                         json.dumps(geom)))
+                self.assertEqual(updated_marker.extras, json.loads(self.ExtrasGood))
+                self.assertEqual(result_json.get('photo_count'), 0)
+                self.assertEqual(result_json.get('audio_count'), 0)
+                self.assertEqual(result_json.get('map_image_count'), 0)
+                self.assertEqual(result_json.get('record_count'), 0)
 
     def test_update_marker_using_patch(self, **kwargs):
         for k in ['Point', 'LineString', 'Polygon']:

--- a/apps/site/managers/overlays.py
+++ b/apps/site/managers/overlays.py
@@ -79,6 +79,17 @@ class MarkerMixin(ObjectMixin):
             access_key=access_key,
             ordering_field=ordering_field)
         return self.append_extras(q, "count", project=project, forms=forms)
+    
+    def get_objects_public_with_lists(
+            self,
+            forms=None,
+            project=None,
+            access_key=None,
+            ordering_field=None):
+        q = self.get_objects_public(
+            access_key=access_key,
+            ordering_field=ordering_field)
+        return self.append_extras(q, "array_agg", project=project, forms=forms)
 
     def to_dict_list(self):
         # does this need to be implemented, or can we just rely on

--- a/apps/site/migrations/0003_marker_extras.py
+++ b/apps/site/migrations/0003_marker_extras.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('site', '0002_create_views_load_data'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='marker',
+            name='extras',
+            field=jsonfield.fields.JSONField(null=True, blank=True),
+        ),
+    ]

--- a/apps/site/models/marker.py
+++ b/apps/site/models/marker.py
@@ -6,7 +6,7 @@ from localground.apps.site.models import BaseUploadedMedia
 from django.contrib.contenttypes import generic
 from localground.apps.site.models import BasePoint, BaseNamed, \
     BaseGenericRelationMixin, ReturnCodes
-
+from jsonfield import JSONField
 
 class Marker(BasePoint, BaseNamed, BaseGenericRelationMixin):
 
@@ -24,6 +24,7 @@ class Marker(BasePoint, BaseNamed, BaseGenericRelationMixin):
     # todo:  replace project with generic association to either a project, view,
     # or presentation :)
     color = models.CharField(max_length=6)
+    extras = JSONField(blank=True, null=True)
     _records_dict = None
     objects = MarkerManager()
     filter_fields = ('id', 'project', 'name', 'descrption', 'tags',)

--- a/apps/templates/rest_framework/horizontal/json.html
+++ b/apps/templates/rest_framework/horizontal/json.html
@@ -1,0 +1,22 @@
+{% load jsonify %}
+<div class="form-group {% if field.errors %}has-error{% endif %}">
+  {% if field.label %}
+    <label class="col-sm-2 control-label {% if style.hide_label %}sr-only{% endif %}">
+      {{ field.label }}
+    </label>
+  {% endif %}
+
+  <div class="col-sm-10">
+    <textarea name="{{ field.name }}" class="form-control" {% if style.placeholder %}placeholder="{{ style.placeholder }}"{% endif %} {% if style.rows %}rows="{{ style.rows }}"{% endif %}>{% if field.value %}{{ field.value|jsonify }}{% endif %}</textarea>
+
+    {% if field.errors %}
+      {% for error in field.errors %}
+        <span class="help-block">{{ error }}</span>
+      {% endfor %}
+    {% endif %}
+
+    {% if field.help_text %}
+      <span class="help-block">{{ field.help_text }}</span>
+    {% endif %}
+  </div>
+</div>

--- a/apps/templatetags/helpers.py
+++ b/apps/templatetags/helpers.py
@@ -15,3 +15,4 @@ key = register.filter('key', key)
 
 
 
+

--- a/apps/templatetags/jsonify.py
+++ b/apps/templatetags/jsonify.py
@@ -1,0 +1,11 @@
+from django import template
+import json
+register = template.Library()
+
+@register.filter
+def jsonify(dictionary):
+    if isinstance(dictionary, dict):
+        return json.dumps(dictionary)
+    return dictionary
+
+register.filter('jsonify', jsonify)

--- a/static/backbone/js/api/lib/maps/data/dataManager.js
+++ b/static/backbone/js/api/lib/maps/data/dataManager.js
@@ -99,7 +99,7 @@ define(["models/project",
                 var that = this,
                     project = new Project({id: projectID});
 
-                project.fetch({data: {format: 'json', include_schema: true}, success: function () {
+                project.fetch({data: {format: 'json', include_metadata: true}, success: function () {
                     that.updateCollections(project);
                 }});
             };


### PR DESCRIPTION
### Summary
* Added more robust testing for Marker endpoint
* Added a new field (extras) to Marker endpoint to accommodate open-ended key-value pairs. To apply schema change, do the following:
  * $ vagrant ssh
  * $ cd /localground/apps
  * $ python manage.py migrate

### To Test
* Make sure Django tests pass
  * $ vagrant ssh
  * $ cd /localground/apps
  * $ python manage.py test
* Try updating the /api/0/markers/ endpoint with different data (see screenshot)
* Make sure there are no errors and the the UI is able to handle the new marker creations / updates

<img width="395" alt="screen shot 2015-10-21 at 12 08 16 pm" src="https://cloud.githubusercontent.com/assets/1214147/10647340/8addffec-77ec-11e5-8256-f939ebd43dd9.png">
