### PR TITLE
setting up flower to run through supervisor

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # within the machine from a port on the host machine. In the example below,
   # accessing "localhost:7777" will access port 80 on the guest machine.
   config.vm.network "forwarded_port", guest: 80, host: 7777
-  config.vm.network "forwarded_port", guest: 9999, host: 9999
+  config.vm.network "forwarded_port", guest: 5555, host: 5555
   # config.vm.network :forwarded_port, guest: 5432, host: 1234
 
   # Create a private network, which allows host-only access to the machine

--- a/deploy_tools/bootstrap.sh
+++ b/deploy_tools/bootstrap.sh
@@ -135,6 +135,10 @@ sudo apt-get -y install supervisor
 sudo cp /localground/deploy_tools/celeryd.conf /etc/supervisor/conf.d/celeryd.conf
 sudo mkdir /var/log/celery
 
+# flower will monitor celery
+sudo cp /localground/deploy_tools/flower.conf /etc/supervisor/conf.d/flower.conf
+
+
 ###############################################
 # Create required Django tables and run tests #
 ###############################################

--- a/deploy_tools/flower.conf
+++ b/deploy_tools/flower.conf
@@ -1,0 +1,25 @@
+; ==================================
+; flower supervisor config 
+; ==================================
+
+[program:flower]
+command=celery flower -A tasks --address=0.0.0.0 --port=5555 --basic_auth=test_user:test_pass
+
+directory=/localground/apps
+user=nobody
+numprocs=1
+stdout_logfile=/var/log/celery/flower.log
+stderr_logfile=/var/log/celery/flower.err
+autostart=true
+autorestart=true
+startsecs=10
+
+; Need to wait for currently executing tasks to finish at shutdown.
+; Increase this if you have very long running tasks.
+stopwaitsecs = 60
+
+; When resorting to send SIGKILL to the program to terminate it
+; send SIGKILL to its whole process group instead,
+; taking care of its children as well.
+killasgroup=true
+

--- a/deploy_tools/iptables
+++ b/deploy_tools/iptables
@@ -5,6 +5,7 @@
 -P OUTPUT ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 80 -j ACCEPT
+-A INPUT -p tcp -m tcp --dport 5555 -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 22 -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -p tcp -m tcp --dport 443 -j ACCEPT

--- a/deploy_tools/requirements.txt
+++ b/deploy_tools/requirements.txt
@@ -31,6 +31,7 @@ six==1.9.0
 South==1.0.2
 SwampDragon==0.4.2.2
 django-celery==3.1.17
+flower==0.9.0
 #MapScript (installed via apt-get (python-mapscript))
 #GDAL (installed via apt-get (python-gdal))
 


### PR DESCRIPTION
This will start flower, which will monitor celery.  You can access it through localhost:5555, but there is a username/password, which is in the config file.  This has been deployed to dev, with a different password.