### PR TITLE
Feature fullscreen carousel

### DIFF
--- a/static/apps/main/templates/left/symbol-item-view.html
+++ b/static/apps/main/templates/left/symbol-item-view.html
@@ -45,7 +45,7 @@
             {{#ifequal display_name ""}}Untitled{{/ifequal}}
 
         </p>
-        <p class="symbol-edit-individual"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>
+        <p class="symbol-edit"><i class="fa fa-pencil" aria-hidden="true"></i></p>
     </a>
 {{else}}
     <a model-id="{{id}}" id="{{id}}" href="#/{{map_id}}/layers/{{layer_id}}/{{dataset.overlay_type}}/{{id}}" {{#if active }}class="highlight"{{/if}}>
@@ -94,5 +94,4 @@
             {{#ifequal display_name ""}}Untitled{{/ifequal}}
         </p>
     </a>
-</div>
 {{/if}}

--- a/static/apps/main/templates/left/symbol-set.html
+++ b/static/apps/main/templates/left/symbol-set.html
@@ -1,12 +1,14 @@
-<div {{#unless isIndividual}}
-<div class="symbol-wrapper" style="background:{{ icon.fillColor }}">
-    <div class="symbol-header">
-    <!-- div class="symbol-header" {{#if empty}}style="display: none;"{{/if}} -->
-        {{{svgIcon}}}
-        <span class="sort-by">{{property}}</span>
-        {{#if isChecked}}<i class="fa fa-eye symbol-display"></i>{{else}}<i class="fa fa-eye-slash symbol-display"></i>{{/if}}
-        <p class="symbol-edit"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>
-    </div>
-{{/unless}}
+<div> {{#unless isIndividual}}
+    <div class="symbol-wrapper" style="background:{{ icon.fillColor }}">
+        <div class="symbol-header">
+        <!-- div class="symbol-header" {{#if empty}}style="display: none;"{{/if}} -->
+            {{{svgIcon}}}
+            <span class="sort-by">{{property}}</span><span class="count">({{count}})</span>
+            {{#if isChecked}}<i class="fa fa-eye symbol-display"></i>{{else}}<i class="fa fa-eye-slash symbol-display"></i>{{/if}}
+            <p class="symbol-edit"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>
+        </div>
+    {{/unless}}
 
-<ul class="symbol"></ul>
+    <ul class="symbol"></ul>
+    </div>
+</div>

--- a/static/apps/main/templates/right/symbol-style-menu.html
+++ b/static/apps/main/templates/right/symbol-style-menu.html
@@ -1,7 +1,7 @@
 <div class="style-menu">
     <div class="style-menu_row">
         <div>
-            <span class="symbol-info">category: {{title}}</span>
+            <span class="symbol-info">category: {{title}} ({{count}} {{items}})</span>
         </div>
         <input type="text" value="{{title}}" class='symbol-title-input'>
     </div>

--- a/static/apps/main/views/left/symbol-collection-view.js
+++ b/static/apps/main/views/left/symbol-collection-view.js
@@ -99,7 +99,8 @@ define(["jquery",
                     map_id: this.mapId,
                     dataset: this.layer.get('dataset'),
                     isIndividual: this.layer.get('group_by') === 'individual',
-                    svgIcon: this.model.toSVG()
+                    svgIcon: this.model.toSVG(),
+                    count: this.collection.length
                 }
             },
 
@@ -119,7 +120,8 @@ define(["jquery",
                 this.symbolMenu = new SymbolStyleMenuView({
                     app: this.app,
                     layer: this.layer,
-                    model: this.model
+                    model: this.model,
+                    collection: this.collection
                 });
                 this.popover.update({
                     $source: this.$el.find('.symbol-header'),

--- a/static/apps/main/views/right/symbol-style-menu-view.js
+++ b/static/apps/main/views/right/symbol-style-menu-view.js
@@ -12,6 +12,7 @@ define(["jquery",
         var MarkerStyleChildView = Marionette.ItemView.extend({
             initialize: function (opts) {
                 _.extend(this, opts);
+                console.log(this.model);
                 this.render();
             },
             template: Handlebars.compile(SymbolStyleMenu),
@@ -39,7 +40,9 @@ define(["jquery",
                     fillOpacity: this.model.get("fillOpacity"),
                     id: "cp" + this.model.get('id'),
                     metadata: this.model,
-                    shape: this.model.get('shape')
+                    shape: this.model.get('shape'),
+                    count: this.collection.length,
+                    items: this.collection.length === 1 ? 'item' : 'items'
                 };
             },
             onRender: function () {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -157,6 +157,7 @@ ul {
   display: flex;
   position: absolute;
   width: 100%;
+  border-top: 1px solid #dcdcdc;
 }
 
 .print-layout-left {
@@ -869,9 +870,62 @@ i.fa.fa.fa-question-circle {
   margin-bottom: 30px;
 }
 
+.fullScreen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 999;
+  background: rgba(0, 0, 0, 0.75);
+}
+
+.fullScreen .carouselbox {
+  position: initial;
+}
+
+.fullScreen .circle-buttons {
+  position: absolute;
+  bottom: 45px;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.fullScreen .next, .fullScreen .prev {
+  height: 100vh;
+  top: 0;
+  transform: translateY(48%);
+}
+
+.fullScreen .photo {
+  height: 100%;
+  width: 100%;
+  max-width: 85vw;
+  max-height: 85vh;
+  margin: 0 auto;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.close-fullscreen {
+  display: none;
+  position: absolute;
+  color: #eee;
+  z-index: 3;
+  margin: 15px;
+  right: 0;
+}
+
+.show-slide {
+  color: #999;
+}
+
 .breadcrumb {
   box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 transparent, 0 2px 4px -1px transparent;
-  z-index: 2;
   position: absolute;
   width: 100%;
   min-height: 44px;

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -456,11 +456,12 @@ ul {
 .sort-by {
   font-size: 12px;
   font-weight: 600;
-  width: 170px;
+  max-width: 158px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
+  display: inline-block;
 }
 
 .count {
@@ -909,6 +910,16 @@ i.fa.fa.fa-question-circle {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
+}
+
+.fullScreen .carousel-caption {
+  position: absolute;
+  bottom: 24px;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
 }
 
 .close-fullscreen {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -454,16 +454,19 @@ ul {
 
 .sort-by {
   font-size: 12px;
-  padding: 8px 0px;
-  /* margin: 10px 0px; */
-  display: inline-block;
-  background-color: white;
   font-weight: 600;
   width: 170px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
   vertical-align: middle;
+}
+
+.count {
+  font-size: 12px;
+  color: #949393;
+  font-weight: 600;
+  margin-left: 4px;
 }
 
 .symbol-wrapper {
@@ -695,16 +698,13 @@ i.fa.fa.fa-question-circle {
 }
 
 .example-markers {
-  /*
-  display: inline-flex;
+  display: flex;
+  flex-flow: row wrap;
   justify-content: center;
-  */
-  width: 100%;
 }
 
 .example-marker-wrapper {
-  margin: -2px;
-  display: inline-block;
+  padding: 2px;
 }
 
 .style-options {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -904,7 +904,7 @@ i.fa.fa.fa-question-circle {
   height: 100%;
   width: 100%;
   max-width: 85vw;
-  max-height: 85vh;
+  max-height: 80vh;
   margin: 0 auto;
   position: absolute;
   left: 50%;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1580,9 +1580,9 @@ tbody .failure-message, tbody .success-message {
 }
 
 
-.carousel .fa {
+/* .carousel .fa {
     color: #999;
-}
+} */
 .carousel-content {
     margin: 0;
     padding: 0;

--- a/static/css/scss/components/_carousel.scss
+++ b/static/css/scss/components/_carousel.scss
@@ -35,6 +35,15 @@
         top: 50%;
         transform: translate(-50%, -50%);
     }
+    .carousel-caption {
+        position: absolute;
+        bottom: 24px;
+        left: 0;
+        right: 0;
+        margin-left: auto;
+        margin-right: auto;
+        text-align: center;
+    }
 }
 
 .close-fullscreen {

--- a/static/css/scss/components/_carousel.scss
+++ b/static/css/scss/components/_carousel.scss
@@ -1,0 +1,51 @@
+.fullScreen {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 999;
+    background: rgba(0,0,0,.75);
+    .carouselbox {
+        position: initial;
+    }
+    .circle-buttons {
+        position: absolute;
+        bottom: 45px;
+        left: 0;
+        right: 0;
+        margin-left: auto;
+        margin-right: auto;
+    }
+    .next, .prev {
+        height: 100vh;
+        top: 0;
+        transform: translateY(48%);
+
+    }
+
+    .photo {
+        height: 100%;
+        width: 100%;
+        max-width: 85vw;
+        max-height: 85vh;
+        margin: 0 auto;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+    }
+}
+
+.close-fullscreen {
+    display: none;
+    position: absolute;
+    color: #eee;
+    z-index: 3;
+    margin: 15px;
+    right: 0;
+}
+
+.show-slide {
+    color: #999;
+}

--- a/static/css/scss/components/_carousel.scss
+++ b/static/css/scss/components/_carousel.scss
@@ -28,7 +28,7 @@
         height: 100%;
         width: 100%;
         max-width: 85vw;
-        max-height: 85vh;
+        max-height: 80vh;
         margin: 0 auto;
         position: absolute;
         left: 50%;

--- a/static/css/scss/components/_index.scss
+++ b/static/css/scss/components/_index.scss
@@ -5,3 +5,4 @@
 @import 'marker_style_menu';
 @import 'symbol_style_menu';
 @import 'data_detail';
+@import 'carousel';

--- a/static/css/scss/components/_marker_style_menu.scss
+++ b/static/css/scss/components/_marker_style_menu.scss
@@ -111,9 +111,8 @@
 }
 
 .example-markers {
-    display: inline-flex;
-    width: 100%;
-    // justify-content: space-evenly;
+    display: flex;
+    flex-flow: row wrap;
     justify-content: center;
 }
 

--- a/static/css/scss/components/_symbol_set.scss
+++ b/static/css/scss/components/_symbol_set.scss
@@ -1,16 +1,18 @@
 // main: ../main-new.scss
 .sort-by {
     font-size: 12px;
-    padding: 8px 0px;
-    /* margin: 10px 0px; */
-    display: inline-block;
-    background-color: white;
     font-weight: 600;
     width: 170px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: middle;
+}
+.count {
+    font-size: 12px;
+    color: #949393;
+    font-weight: 600;
+    margin-left: 4px;   
 }
 
 .symbol-wrapper {

--- a/static/css/scss/components/_symbol_set.scss
+++ b/static/css/scss/components/_symbol_set.scss
@@ -2,11 +2,12 @@
 .sort-by {
     font-size: 12px;
     font-weight: 600;
-    width: 170px;
+    max-width: 158px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
     vertical-align: middle;
+    display: inline-block;
 }
 .count {
     font-size: 12px;

--- a/static/css/scss/layout/_main_panel.scss
+++ b/static/css/scss/layout/_main_panel.scss
@@ -5,4 +5,5 @@
     display: flex;
     position: absolute;
     width: 100%;
+    border-top: 1px solid #dcdcdc;
 }

--- a/static/css/scss/widgets/_breadcrumbs.scss
+++ b/static/css/scss/widgets/_breadcrumbs.scss
@@ -3,7 +3,7 @@ $icon-line-height: 34px;
 
 .breadcrumb {
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
-    z-index: 2;
+    // z-index: 2;
     position: absolute;
     width: 100%;
     min-height: 44px;

--- a/static/lib/carousel/carousel-container.html
+++ b/static/lib/carousel/carousel-container.html
@@ -17,7 +17,7 @@
     {{/compare}}
 
 {{else}}
-
+    <i class="fa fa-times fa-3x close-fullscreen"></i>
     <div class="carouselbox">
         <ol class="carousel-content"></ol>
     </div>

--- a/static/lib/carousel/carousel-photo-item.html
+++ b/static/lib/carousel/carousel-photo-item.html
@@ -1,4 +1,10 @@
-<div class="photo" style="background: url('{{this.path_medium}}');"></div>
+<div class="photo {{fullScreen}}" 
+    {{#if fullScreen}} 
+        style="background: url('{{this.path_large}}');" 
+    {{else}}           
+        style="background: url('{{this.path_medium}}');"
+    {{/if}}>
+</div>
 <div class="carousel-caption-wrapper">
     <p class="carousel-caption" style="color: {{paragraph.color}}; font-family: {{paragraph.font}}">{{this.caption }}</p>
 <div>

--- a/static/lib/carousel/carousel.js
+++ b/static/lib/carousel/carousel.js
@@ -167,15 +167,14 @@ define(["jquery", "underscore", "marionette", "handlebars",
                 this.counter = parseInt($(e.target).attr("data-index"), 10);
                 this.navigate();
             },
-            showFullScreen: function(e) {
+            showFullScreen: function() {
                 if (this.$el.hasClass('fullScreen')) {
                     return;
                 }
-                console.log('clicked photo, show fullScreen');
-                console.log(this.$el.find('.carousel'));
                 this.hideArrows();
                 this.fullScreen = true;
                 this.$el.find('.close-fullscreen').show();
+                
                 this.children.each(function(child) {
                     child.fullScreen = true;
                     child.render();

--- a/static/lib/carousel/carousel.js
+++ b/static/lib/carousel/carousel.js
@@ -15,13 +15,16 @@ define(["jquery", "underscore", "marionette", "handlebars",
                 "click .show-slide": "jump",
                 "click .close": "closeCarousel",
                 'mouseover .carouselbox': 'showArrows',
-                'mouseout .carouselbox': 'hideArrows'
+                'mouseout .carouselbox': 'hideArrows',
+                'click .photo': 'showFullScreen',
+                'click .close-fullscreen': 'exitFullScreen'
             },
             counter: 0,
             className: "active-slide",
             childViewContainer: ".carousel-content",
             initialize: function (opts) {
                 _.extend(this, opts);
+                this.fullScreen = false;
                 if (this.mode == "photos") {
                     this.template = Handlebars.compile(CarouselContainerTemplate);
                 } else if (this.mode == "videos") {
@@ -63,7 +66,8 @@ define(["jquery", "underscore", "marionette", "handlebars",
                     app: this.app,
                     num_children: this.collection.length,
                     parent: this,
-                    panelStyles: this.panelStyles
+                    panelStyles: this.panelStyles,
+                    fullScreen: this.fullScreen
                 };
             },
             getChildView: function () {
@@ -79,13 +83,15 @@ define(["jquery", "underscore", "marionette", "handlebars",
                         }
                     },
                     templateHelpers: function () {
+                        console.log('template helpers', this.fullScreen, parent.fullScreen);
                         var paragraph;
                         if (this.panelStyles) {
                             paragraph = this.panelStyles.paragraph;
                         }
                         return {
                             num_children: this.num_children,
-                            paragraph: paragraph
+                            paragraph: paragraph,
+                            fullScreen: this.fullScreen
                         };
                     },
                     tagName: "li",
@@ -111,7 +117,8 @@ define(["jquery", "underscore", "marionette", "handlebars",
                 return {
                     num_children: this.collection.length,
                     isSpreadsheet: this.app.screenType === "spreadsheet",
-                    paragraph: paragraph
+                    paragraph: paragraph,
+                    fullScreen: this.fullScreen
                 };
             },
 
@@ -158,6 +165,31 @@ define(["jquery", "underscore", "marionette", "handlebars",
                 this.resetCurrentFrame();
                 this.counter = parseInt($(e.target).attr("data-index"), 10);
                 this.navigate();
+            },
+            showFullScreen: function(e) {
+                if (this.$el.hasClass('fullScreen')) {
+                    return;
+                }
+                console.log('clicked photo, show fullScreen');
+                console.log(this.$el.find('.carousel'));
+                this.hideArrows();
+                this.fullScreen = true;
+                this.$el.find('.close-fullscreen').show();
+                this.children.each(function(child) {
+                    child.fullScreen = true;
+                    child.render();
+                });
+                //this.render();
+                this.$el.addClass('fullScreen');
+            },
+            exitFullScreen: function() {
+                this.fullScreen = false;
+                this.$el.find('.close-fullscreen').hide();
+                this.children.each(function(child) {
+                    child.fullScreen = false;
+                    child.render();
+                });
+                this.$el.removeClass('fullScreen');
             }
         });
         return Carousel;

--- a/static/models/symbol.js
+++ b/static/models/symbol.js
@@ -202,7 +202,7 @@ define(['backbone', 'underscore', 'collections/records',
                 const props = _.extend(
                     Symbol._getDefaultMetadataProperties(metadata), {
                         'rule': `id = ${value}`,
-                        'title': value,
+                        'title': value || 'unititled',
                         'id': id,
                         'fillColor': fillColor
                     });

--- a/static/tests/spec/lib/carousel-test.js
+++ b/static/tests/spec/lib/carousel-test.js
@@ -55,12 +55,19 @@ define([
             it('Listens for fullscreen click', function () {
                 this.carousel.render();
                 const $el = this.carousel.$el;
-                expect($el.hasClass('fullScreen')).toBeFalsy();$el.find('div.photo:first-child').trigger('click');
+                expect($el.hasClass('fullScreen')).toBeFalsy();
+                $el.find('div.photo:first-child').trigger('click');
                 expect($el.hasClass('fullScreen')).toBeTruthy();
             });
 
             it('Listens for hide fullscreen click', function () {
-                expect(1).toEqual(0);
+                this.carousel.render();
+                const $el = this.carousel.$el;
+                expect($el.hasClass('fullScreen')).toBeFalsy();
+                $el.find('div.photo:first-child').trigger('click');
+                expect($el.hasClass('fullScreen')).toBeTruthy();
+                $el.find('.close-fullscreen').trigger('click');
+                expect($el.hasClass('fullScreen')).toBeFalsy();
             });
         });
 
@@ -70,62 +77,98 @@ define([
                 initCarousel(this);
             });
             it('showFullScreen() works', function () {
-                expect(1).toEqual(0);
+                this.carousel.render();
+                expect(Carousel.prototype.showFullScreen).toHaveBeenCalledTimes(0);
+                expect(this.carousel.fullScreen).toEqual(false);
+                expect(this.carousel.$el.find('.close-fullscreen').css('display')).toEqual('');
+                this.carousel.children.each((child) => {
+                    expect(child.fullScreen).toEqual(false);
+                });
+                expect(this.carousel.$el).not.toHaveClass('fullScreen');
+
+                this.carousel.showFullScreen();
+
+                expect(Carousel.prototype.showFullScreen).toHaveBeenCalledTimes(1);
+                expect(this.carousel.fullScreen).toEqual(true);
+                expect(this.carousel.$el.find('.close-fullscreen').css('display')).toEqual('inline');
+                this.carousel.children.each((child) => {
+                    expect(child.fullScreen).toEqual(true);
+                });
+                expect(this.carousel.$el).toHaveClass('fullScreen');
             });
             it('exitFullScreen() works', function () {
-                expect(1).toEqual(0);
+                this.carousel.render();
+                this.carousel.showFullScreen();
+
+                expect(Carousel.prototype.exitFullScreen).toHaveBeenCalledTimes(0);
+                expect(this.carousel.fullScreen).toEqual(true);
+                expect(this.carousel.$el.find('.close-fullscreen').css('display')).toEqual('inline');
+                this.carousel.children.each((child) => {
+                    expect(child.fullScreen).toEqual(true);
+                });
+                expect(this.carousel.$el).toHaveClass('fullScreen');
+                
+                this.carousel.exitFullScreen();
+
+                expect(Carousel.prototype.exitFullScreen).toHaveBeenCalledTimes(1);
+                expect(this.carousel.fullScreen).toEqual(false);
+                expect(this.carousel.$el.find('.close-fullscreen').css('display')).toEqual('none');
+                this.carousel.children.each((child) => {
+                    expect(child.fullScreen).toEqual(false);
+                });
+                expect(this.carousel.$el).not.toHaveClass('fullScreen');
             });
-            it('initialize() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('showArrows() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('hideArrows() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('closeCarousel() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('childViewOptions() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('getChildView() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('templateHelpers() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('navigate() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('resetCurrentFrame() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('next() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('prev() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('updateCircles() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
-            it('jump() works', function () {
-                // TODO eventually: implement these stubs.
-                expect(1).toEqual(1);
-            });
+            // it('initialize() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('showArrows() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('hideArrows() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('closeCarousel() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('childViewOptions() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('getChildView() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('templateHelpers() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('navigate() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('resetCurrentFrame() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('next() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('prev() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('updateCircles() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
+            // it('jump() works', function () {
+            //     // TODO eventually: implement these stubs.
+            //     expect(1).toEqual(1);
+            // });
         });
     });

--- a/static/views/data-detail.js
+++ b/static/views/data-detail.js
@@ -300,7 +300,7 @@ define([
                 panelStyles = this.panelStyles;
             }
             if (photos.length > 0 || videos.length > 0) {
-                console.log("Finding carousel photos / videos")
+                console.log("Finding carousel photos / videos", photos);
                 genericList = [];
                 genericList = genericList.concat(photos.toJSON());
                 genericList = genericList.concat(videos.toJSON());


### PR DESCRIPTION
This branch implements a fullscreen carousel. Merge this branch into master after merging 'bug_symbol-items' into master.

Click on an image in the photo carousel to open the fullscreen carousel.

![screen shot 2018-06-14 at 7 03 31 pm](https://user-images.githubusercontent.com/20868615/41446660-ab332fb0-7005-11e8-8343-b5d1d01e7ed8.png)

Note: This implementation also works with videos. However, there is one sort of bug. When you click on a video that is in the carousel (e.g. a youtube video), is simple starts the video, rather than opening the fullscreen carousel. I think that's pretty much what you'd expect, and probably not a problem, but I just wanted to note it here.  
