### PR TITLE
fixed presentation fullscreen carousel and improved legend

### DIFF
--- a/apps/templates/pages/presentation.html
+++ b/apps/templates/pages/presentation.html
@@ -7,6 +7,7 @@
     <link rel=stylesheet type="text/css" href="/static/css/style.css" />
     <link rel=stylesheet type="text/css" href="/static/css/map-presentation.css" />
     <link rel=stylesheet type="text/css" href="/static/css/main.css" />
+    <link rel=stylesheet type="text/css" href="/static/css/main-new.css" />
     <script>
         var projectJSON = {% autoescape off %}{{project}}{% endautoescape %};
         var mapJSON = {% autoescape off %}{{map}}{% endautoescape %};
@@ -14,16 +15,16 @@
 </head>
 <body>
     <div class="main-panel presentation-main-panel none">
+            <div id="presentation-title" ></div>
         <div id="map-panel">
             <div id="map"></div>
         </div>
         <div id="marker-detail-panel" class="side-panel">
             <!-- Marker list goes here -->
         </div>
-
+        <div id="legend" style="display:none;" ></div>
     </div>
-    <div id="presentation-title" ></div>
-    <div id="legend" style="display:none;" ></div>
+    
 
     <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyA15wvaiyd_TXf10qLAE29UHJasLbptvN4&libraries=places"></script>
     {% if DEBUG %}

--- a/static/apps/presentation/templates/legend-container.html
+++ b/static/apps/presentation/templates/legend-container.html
@@ -3,4 +3,7 @@
         <p class="legend-top-text">Legend</p>
         <i class="fa fa-angle-down legend-toggle" aria-hidden="true"></i>
     </div>
+    <div class='legend-layers'>
+
+    </div>
 </div>

--- a/static/apps/presentation/views/layer-list-manager.js
+++ b/static/apps/presentation/views/layer-list-manager.js
@@ -25,6 +25,7 @@ define(["marionette",
                 };
             },
             childView: LayerEntryView,
+            childViewContainer: '.legend-layers',
 
             toggleLegend: function () {
                 const $legend = $('#legend');

--- a/static/css/map-presentation.css
+++ b/static/css/map-presentation.css
@@ -656,7 +656,6 @@ Separate Mobile CSS
     padding: 10px 20px;
     transition: 0.5s;
     overflow-y: hidden;
-
    /* min-height: 200px;*/
 }
 
@@ -671,6 +670,11 @@ Separate Mobile CSS
 .legend-toggle {
     margin-top: 4px;
     float: right;
+}
+
+.legend-layers {
+    overflow-y: scroll;
+    max-height: 85vh;
 }
 
 #presentation-title {

--- a/static/lib/carousel/carousel.js
+++ b/static/lib/carousel/carousel.js
@@ -179,7 +179,6 @@ define(["jquery", "underscore", "marionette", "handlebars",
                     child.fullScreen = true;
                     child.render();
                 });
-                //this.render();
                 this.$el.addClass('fullScreen');
             },
             exitFullScreen: function() {


### PR DESCRIPTION
I updated the presentation app so that the fullscreen carousel works. The main thing I had to do was update the html structure of the app so that the stacking order of the elements worked. 

While I was there, I also updated the legend so that the legend container scrolls when there are too many elements (like 25+), rather than pushing down the height of the entire screen. 