### PR TITLE
615 leftpanel refactor

### DIFF
--- a/static/apps/main/templates/left/layer-item.html
+++ b/static/apps/main/templates/left/layer-item.html
@@ -16,11 +16,9 @@
     </div>
     {{#if hasData}}
     <div class="layer-column lc-3">
-        {{#unless isIndividual}}
-        <span class="collapse-wrapper">
+        <span class="collapse-wrapper" style="display:{{#if isIndividual}} none {{else}} inline {{/if}} ">
             <i class="fa fa-caret-down fa-lg collapse"></i>
         </span>
-        {{/unless}}
         <a class="layer-style-by"><span >styled by: </span><span id="layer-style-by">{{group_by}}</span></a>
     </div>
     {{/if}}

--- a/static/apps/main/templates/left/layer-item.html
+++ b/static/apps/main/templates/left/layer-item.html
@@ -16,9 +16,11 @@
     </div>
     {{#if hasData}}
     <div class="layer-column lc-3">
+        {{#unless isIndividual}}
         <span class="collapse-wrapper">
             <i class="fa fa-caret-down fa-lg collapse"></i>
         </span>
+        {{/unless}}
         <a class="layer-style-by"><span >styled by: </span><span id="layer-style-by">{{group_by}}</span></a>
     </div>
     {{/if}}

--- a/static/apps/main/templates/left/symbol-item-view.html
+++ b/static/apps/main/templates/left/symbol-item-view.html
@@ -8,7 +8,7 @@
             {{display_name}}
             {{#ifequal display_name ""}}Untitled{{/ifequal}}
         </p>
-        <p class="symbol-edit"><i class="fa fa-pencil" aria-hidden="true"></i></p>
+        <p class="symbol-edit"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>
     </a>
 {{else}}
     <a model-id="{{id}}" id="{{id}}" href="#/{{map_id}}/layers/{{layer_id}}/{{dataset.overlay_type}}/{{id}}" {{#if active }}class="highlight"{{/if}}>

--- a/static/apps/main/templates/left/symbol-set.html
+++ b/static/apps/main/templates/left/symbol-set.html
@@ -2,7 +2,7 @@
     <div class="symbol-wrapper" style="background:{{ icon.fillColor }}">
         <div class="symbol-header">
         <!-- div class="symbol-header" {{#if empty}}style="display: none;"{{/if}} -->
-            <span class='symbol-level-svg'>{{{svgIcon}}}</span>
+            <span class='symbol-level-svg' {{#if notCollapsed}}style='display: none;'{{/if}}>{{{svgIcon}}}</span>
             <span class="sort-by">{{property}}</span><span class="count">({{count}})</span>
             {{#if isChecked}}<i class="fa fa-eye symbol-display"></i>{{else}}<i class="fa fa-eye-slash symbol-display"></i>{{/if}}
             <p class="symbol-edit"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>

--- a/static/apps/main/templates/left/symbol-set.html
+++ b/static/apps/main/templates/left/symbol-set.html
@@ -2,7 +2,7 @@
     <div class="symbol-wrapper" style="background:{{ icon.fillColor }}">
         <div class="symbol-header">
         <!-- div class="symbol-header" {{#if empty}}style="display: none;"{{/if}} -->
-            {{{svgIcon}}}
+            <span class='symbol-level-svg'>{{{svgIcon}}}</span>
             <span class="sort-by">{{property}}</span><span class="count">({{count}})</span>
             {{#if isChecked}}<i class="fa fa-eye symbol-display"></i>{{else}}<i class="fa fa-eye-slash symbol-display"></i>{{/if}}
             <p class="symbol-edit"><i class="fa fa-pencil-alt" aria-hidden="true"></i></p>

--- a/static/apps/main/views/left/layer-list-child-view1.js
+++ b/static/apps/main/views/left/layer-list-child-view1.js
@@ -76,7 +76,8 @@ define(["marionette",
                     project: this.app.dataManager.getProject(),
                     name: this.dataCollection.name,
                     isChecked: this.model.get("metadata").isShowing,
-                    hasData: !this.isEmpty()
+                    hasData: !this.isEmpty(),
+                    isIndividual: this.model.isIndividual()
                 };
             },
             childView: SymbolView,

--- a/static/apps/main/views/left/layer-list-child-view1.js
+++ b/static/apps/main/views/left/layer-list-child-view1.js
@@ -259,12 +259,14 @@ define(["marionette",
                     this.$el.find('.symbol-item').css('display', 'block');
                     this.$el.find('.collapse').removeClass('fa-caret-up');
                     this.$el.find('.collapse').addClass('fa-caret-down');
+                    this.$el.find('.symbol-level-svg').hide();
                 } else {
                     this.model.get('metadata').collapsed = true;
                     this.$el.find('.symbol').css('height', 0);
                     this.$el.find('.symbol-item').css('display', 'none');
                     this.$el.find('.collapse').removeClass('fa-caret-down');
                     this.$el.find('.collapse').addClass('fa-caret-up');
+                    this.$el.find('.symbol-level-svg').show();
                 }
             },
 

--- a/static/apps/main/views/left/layer-list-child-view1.js
+++ b/static/apps/main/views/left/layer-list-child-view1.js
@@ -122,6 +122,11 @@ define(["marionette",
                 this.$el.find('#layer-style-by').html(
                     this.model.get('group_by')
                 );
+                if (this.model.isIndividual()) {
+                    this.$el.find('.collapse-wrapper').css('display', 'none');
+                } else {
+                    this.$el.find('.collapse-wrapper').css('display', 'inline');
+                }
             },
             childViewOptions: function (model, index) {
                 return {

--- a/static/apps/main/views/left/symbol-collection-view.js
+++ b/static/apps/main/views/left/symbol-collection-view.js
@@ -45,13 +45,14 @@ define(["jquery",
             childViewOptions: function (model, index) {
                 return {
                     app: this.app,
-                    parent: this
+                    parent: this,
+                    symbolModel: this.model
                 };
             },
             events: {
                 //edit event here, pass the this.model to the right panel
                 'click .layer-delete' : 'deleteLayer',
-                'click .symbol-edit': 'showSymbolEditMenu',
+                'click .symbol-header .symbol-edit': 'showSymbolEditMenu',
                 'click .symbol-display': 'showHideOverlays',
                 'mouseenter .symbol-edit': 'highlightSymbolContent',
                 'mouseleave .symbol-edit': 'unHighlightSymbolContent'
@@ -100,7 +101,7 @@ define(["jquery",
                     dataset: this.layer.get('dataset'),
                     isIndividual: this.layer.get('group_by') === 'individual',
                     svgIcon: this.model.toSVG(),
-                    count: this.collection.length,
+                    count: this.collection ? this.collection.length : 1,
                     notCollapsed: !this.layer.get('metadata').collapsed
                 }
             },

--- a/static/apps/main/views/left/symbol-collection-view.js
+++ b/static/apps/main/views/left/symbol-collection-view.js
@@ -100,7 +100,8 @@ define(["jquery",
                     dataset: this.layer.get('dataset'),
                     isIndividual: this.layer.get('group_by') === 'individual',
                     svgIcon: this.model.toSVG(),
-                    count: this.collection.length
+                    count: this.collection.length,
+                    notCollapsed: !this.layer.get('metadata').collapsed
                 }
             },
 

--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -120,7 +120,8 @@ define(["marionette",
                     $source: this.$el.find('.ind-symbol'),
                     view: new SymbolStyleMenuView({
                         app: this.app,
-                        model: this.symbolModel
+                        model: this.symbolModel,
+                        layer: this.parent.layer
                     }),
                     placement: 'right',
                     offsetX: '5px',

--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -61,7 +61,6 @@ define(["marionette",
             },
             getSVG: function () {
                 const icon = this.symbolModel.get('icon');
-                console.log(this.model);
                 // const geomType = this.model.get('geometry') ? this.model.get('geometry').type : 'Point';
                 if (this.model.get('geometry') === null) {
                     return;

--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -61,6 +61,11 @@ define(["marionette",
             },
             getSVG: function () {
                 const icon = this.symbolModel.get('icon');
+                console.log(this.model);
+                // const geomType = this.model.get('geometry') ? this.model.get('geometry').type : 'Point';
+                if (this.model.get('geometry') === null) {
+                    return;
+                }
                 const geomType = this.model.get('geometry').type;
                 if (geomType === 'Point') {
                     return this.symbolModel.toSVG();

--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -36,7 +36,7 @@ define(["marionette",
                 'change': 'render'
             },
             events: {
-                'click .symbol-edit-individual': 'showSymbolEditMenu'
+                'click .ind-symbol .symbol-edit': 'showSymbolEditMenu'
             },
             template: Handlebars.compile(SymbolItemTemplate),
             tagName: "li",
@@ -52,7 +52,7 @@ define(["marionette",
                     rule: this.symbolModel.get('rule'),
                     icon: this.symbolModel.get('icon'),
                     svg: svg,
-                    isIndividual: this.parent.layer.get('group_by') === 'individual',
+                    isIndividual: this.parent.layer.isIndividual(),
                     width: this.symbolModel.get('width'),
                     height: this.symbolModel.get('height'),
                     display_name: display_name === undefined ? "" : display_name,
@@ -115,7 +115,7 @@ define(["marionette",
                 }
             },
 
-            showSymbolEditMenu: function (event) {
+            showSymbolEditMenu: function (e) {
                 this.popover.update({
                     $source: this.$el.find('.ind-symbol'),
                     view: new SymbolStyleMenuView({
@@ -124,9 +124,10 @@ define(["marionette",
                     }),
                     placement: 'right',
                     offsetX: '5px',
-                    width: '350px',
-                    title: 'Symbol Properties'
+                    width: '220px',
+                    title: '    '
                 });
+                e.stopImmediatePropagation();
             },
 
             makeActive: function (e) {

--- a/static/apps/main/views/right/symbol-style-menu-view.js
+++ b/static/apps/main/views/right/symbol-style-menu-view.js
@@ -34,6 +34,7 @@ define(["jquery",
 
             tagName: "div",
             templateHelpers: function () {
+                const len = (this.collection) ? this.collection.length : 1;
                 return {
                     groupBy: this.groupBy,
                     icons: IconLookup.getIcons(),
@@ -41,8 +42,8 @@ define(["jquery",
                     id: "cp" + this.model.get('id'),
                     metadata: this.model,
                     shape: this.model.get('shape'),
-                    count: this.collection.length,
-                    items: this.collection.length === 1 ? 'item' : 'items'
+                    count: len,
+                    items: len === 1 ? 'item' : 'items'
                 };
             },
             onRender: function () {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -470,7 +470,7 @@ ul {
 }
 
 .symbol-wrapper {
-  padding-left: 4px;
+  padding-left: 7px;
 }
 
 .symbol-header {
@@ -478,6 +478,7 @@ ul {
   padding: 0px 7px;
   border-top: 3px solid white;
   border-right: 3px solid white;
+  height: 28px;
 }
 
 .symbol-edit, .symbol-display, .symbol-edit-individual {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -442,14 +442,14 @@ ul {
   margin-left: 4px;
   display: inline;
   color: #8bb8ed;
-  font-weight: bold;
+  font-weight: 600;
   position: absolute;
   left: 26px;
 }
 
 .layer-style-by span {
   color: inherit;
-  font-weight: bold;
+  font-weight: 600;
 }
 
 .layer-style-by:hover {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -321,7 +321,7 @@ ul {
 }
 
 .layer-container {
-  background: white;
+  background: #f7f7f7;
   padding-top: 10px;
   border-top: 1px solid #e4e5eb;
 }

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -397,6 +397,8 @@ ul {
 .layer-container .lc-3 {
   padding-bottom: 14px;
   border-bottom: 1px solid #e8e8e8;
+  position: relative;
+  height: 15px;
 }
 
 .layer-container .geometry-list-wrapper {
@@ -441,6 +443,8 @@ ul {
   display: inline;
   color: #8bb8ed;
   font-weight: bold;
+  position: absolute;
+  left: 26px;
 }
 
 .layer-style-by span {
@@ -470,21 +474,25 @@ ul {
 }
 
 .symbol-wrapper {
-  padding-left: 7px;
+  padding-left: 5px;
+  border-bottom: 1px solid #e8e8e8;
 }
 
 .symbol-header {
   background: white;
-  padding: 0px 7px;
+  background: white;
+  padding: 0px 7px 0px 23px;
   border-top: 3px solid white;
   border-right: 3px solid white;
-  height: 28px;
+  height: 23px;
+  line-height: 28px;
 }
 
 .symbol-edit, .symbol-display, .symbol-edit-individual {
-  padding-top: 8px;
+  padding-top: 6px;
   padding-right: 6px;
   float: right;
+  font-size: 16px;
 }
 
 .symbol-edit, .symbol-edit-individual {
@@ -500,7 +508,8 @@ ul {
 }
 
 .symbol-header:hover .symbol-edit,
-.symbol-header:hover .symbol-display {
+.symbol-header:hover .symbol-display,
+.symbol-item:hover .symbol-edit {
   display: inline;
   cursor: pointer;
 }
@@ -540,7 +549,7 @@ ul {
   padding: 4px 0px;
   display: inline-block;
   font-weight: 600;
-  width: 170px;
+  width: 160px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -558,6 +567,8 @@ ul {
 .symbol {
   border-left: 1px solid #e4e5eb;
   border-bottom: 3px solid white;
+  padding-bottom: 7px;
+  background: white;
 }
 
 .symbol .highlight {
@@ -600,7 +611,7 @@ i.fa.fa.fa-question-circle {
 
 .symbol-item a, .symbol-item > div {
   text-decoration: none;
-  padding: 6px 32px;
+  padding: 2px 32px 2px 34px;
   display: inline-block;
   width: 100%;
 }

--- a/static/css/scss/components/_layer_list_item.scss
+++ b/static/css/scss/components/_layer_list_item.scss
@@ -65,6 +65,8 @@
     .lc-3 {
         padding-bottom: 14px;
         border-bottom: 1px solid #e8e8e8;
+        position: relative;
+        height: 15px;
     }
     .geometry-list-wrapper {
         left: 200px;
@@ -113,6 +115,8 @@
     display: inline;
     color: #8bb8ed;
     font-weight: bold;
+    position: absolute;
+    left: 26px;
     span {
         color: inherit;
         font-weight: bold;

--- a/static/css/scss/components/_layer_list_item.scss
+++ b/static/css/scss/components/_layer_list_item.scss
@@ -1,6 +1,6 @@
 // main: ../main-new.scss
 .layer-container {
-    background: white;
+    background: #f7f7f7;
     padding-top: 10px;
     border-top: 1px solid #e4e5eb;
     .layer-name {

--- a/static/css/scss/components/_layer_list_item.scss
+++ b/static/css/scss/components/_layer_list_item.scss
@@ -114,12 +114,12 @@
     margin-left: 4px;
     display: inline;
     color: #8bb8ed;
-    font-weight: bold;
+    font-weight: 600;
     position: absolute;
     left: 26px;
     span {
         color: inherit;
-        font-weight: bold;
+        font-weight: 600;
     }
     &:hover {
         text-decoration: underline;

--- a/static/css/scss/components/_symbol_set.scss
+++ b/static/css/scss/components/_symbol_set.scss
@@ -16,23 +16,26 @@
 }
 
 .symbol-wrapper {
-    // border-bottom: 1px solid #ebebeb;
-    padding-left: 7px;
+    padding-left: 5px;
+    border-bottom: 1px solid #e8e8e8;
 }
 
 .symbol-header {
     background: white;
     // border-top: 1px solid #ebebeb;
-    padding: 0px 7px;
+    background: white;
+    padding: 0px 7px 0px 23px;
     border-top: 3px solid white;
     border-right: 3px solid white;
-    height: 28px;
+    height: 23px;
+    line-height: 28px;
 }
 
 .symbol-edit, .symbol-display, .symbol-edit-individual {
-    padding-top: 8px;
+    padding-top: 6px;
     padding-right: 6px;
     float: right;
+    font-size: 16px;
 }
 .symbol-edit, .symbol-edit-individual {
     display: none;
@@ -45,7 +48,8 @@
 }
 
 .symbol-header:hover .symbol-edit,
-.symbol-header:hover .symbol-display {
+.symbol-header:hover .symbol-display,
+.symbol-item:hover .symbol-edit {
     display: inline;
     cursor: pointer;
 
@@ -85,7 +89,7 @@
     padding: 4px 0px;
     display: inline-block;
     font-weight: 600;
-    width: 170px;
+    width: 160px;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -101,6 +105,8 @@
 .symbol {
     border-left: 1px solid #e4e5eb;
     border-bottom: 3px solid white;
+    padding-bottom: 7px;
+    background: white;
 
     .highlight {
         background: rgb(123, 155, 225);
@@ -143,7 +149,7 @@ i.fa.fa.fa-question-circle {
 
     a, >div {
         text-decoration: none;
-        padding: 6px 32px;
+        padding: 2px 32px 2px 34px;
         display: inline-block;
         width: 100%;
     }

--- a/static/css/scss/components/_symbol_set.scss
+++ b/static/css/scss/components/_symbol_set.scss
@@ -17,7 +17,7 @@
 
 .symbol-wrapper {
     // border-bottom: 1px solid #ebebeb;
-    padding-left: 4px;
+    padding-left: 7px;
 }
 
 .symbol-header {
@@ -26,6 +26,7 @@
     padding: 0px 7px;
     border-top: 3px solid white;
     border-right: 3px solid white;
+    height: 28px;
 }
 
 .symbol-edit, .symbol-display, .symbol-edit-individual {

--- a/static/models/symbol.js
+++ b/static/models/symbol.js
@@ -202,7 +202,7 @@ define(['backbone', 'underscore', 'collections/records',
                 const props = _.extend(
                     Symbol._getDefaultMetadataProperties(metadata), {
                         'rule': `id = ${value}`,
-                        'title': value,
+                        'title': value || 'Untitled',
                         'id': id,
                         'fillColor': fillColor
                     });

--- a/static/tests/spec/views/main/layer-list-child-view-test.js
+++ b/static/tests/spec/views/main/layer-list-child-view-test.js
@@ -141,11 +141,13 @@ define([
                 expect(this.view.$el.find('.collapse')).toHaveClass('fa-caret-up');
                 expect(this.view.$el.find('.symbol').css('height')).toEqual('0px');
                 expect(this.view.$el.find('.symbol-item').css('display')).toEqual('none');
+                expect(this.view.$el.find('.symbol-level-svg').css('display')).toEqual('inline');
 
                 this.view.$el.find('.collapse').trigger('click');
 
                 expect(this.view.$el.find('.collapse')).toHaveClass('fa-caret-down');
                 expect(this.view.$el.find('.symbol-item').css('display')).toEqual('block');
+                expect(this.view.$el.find('.symbol-level-svg').css('display')).toEqual('none');
             });
 
             it("Layer checkbox hides and shows Layer content and icons", function() {
@@ -216,8 +218,12 @@ define([
                 this.view.render();
                 expect(this.view.model.get('group_by')).toEqual('height');
                 expect(this.view.$el.find('#layer-style-by').text()).toEqual('height');
+                expect(this.view.$el.find('.collapse-wrapper').css('display')).toEqual('inline');
+
                 this.view.model.set('group_by', 'individual');
+
                 expect(this.view.$el.find('#layer-style-by').text()).toEqual('individual');
+                expect(this.view.$el.find('.collapse-wrapper').css('display')).toEqual('none');
             });
         });
         describe("LayerListChildView, categorical: ", function () {


### PR DESCRIPTION
Changes in this PR:
- Layer headers now have a light gray background.
- expanded categories now longer show category-level icon, but collapsed categories do.
- Can no longer collapse symbols where groupy_by is set to 'individual'
- css updates as discussed on 6/18/2018
- pencil/edit icon now shows for symbols where groupy_by is set to 'individual'

Question:
Should 'Individual' symbols also have the eye-icons for hide/show? I would think so, but I just want to confirm.