### PR TITLE
Disallow final map deletion

### DIFF
--- a/static/apps/main/views/left/left-panel.js
+++ b/static/apps/main/views/left/left-panel.js
@@ -53,6 +53,10 @@ define(["underscore",
             },
 
             deleteMap: function () {
+                if (this.app.dataManager.getMaps().length < 2) {
+                    alert("You are trying to delete your only map. You must have at least one map at all times. Please create a new map before deleting the current one.")
+                    return;
+                }
                 if (!confirm("Are you sure you want to delete this map?")) {
                     return;
                 }

--- a/static/tests/spec/views/main/left-panel-view-test.js
+++ b/static/tests/spec/views/main/left-panel-view-test.js
@@ -127,6 +127,23 @@ define([
 
             });
 
+            it("user cannot delete last map", function () {
+                lpv.render();
+                
+                expect(lpv.app.dataManager.getMaps().length).toEqual(2);
+
+                // have to remove the map manually to actually get rid of it in Jasmine
+                lpv.app.dataManager.getMaps().remove(lpv.model);
+
+                expect(lpv.app.dataManager.getMaps().length).toEqual(1);
+
+                spyOn(window, 'alert').and.returnValue(true);
+                lpv.$el.find('#map-delete').trigger('click');
+                
+                // test that last map is still there
+                expect(lpv.app.dataManager.getMaps().length).toEqual(1);
+            });
+
             it('scrollToLayer(layer) works', function () {
                 lpv.render();
                 spyOn(lpv.layers.$el, 'animate').and.callThrough();


### PR DESCRIPTION
If a user only has one map, they can no longer delete it. Here is the prompt that informs them about the issue. 
![screen shot 2018-08-24 at 2 24 15 pm](https://user-images.githubusercontent.com/20868615/44608712-8ce61280-a7a9-11e8-9982-2bdae17dfbe1.png)

Just a small modification in the deleteMap() function of left-panel.js
