### PR TITLE
Title card display

### DIFF
--- a/static/apps/presentation/presentation-app.js
+++ b/static/apps/presentation/presentation-app.js
@@ -150,8 +150,12 @@ define([
                 model: this.model.getTitleCardModel(),
                 app: this,
             });
-            this.unhideDetail();
-            this.sideRegion.show(titleCardView);
+            if (this.model.get('metadata').displayTitleCard) {
+                this.unhideDetail();
+                this.sideRegion.show(titleCardView);
+            }
+            // this.unhideDetail();
+            // this.sideRegion.show(titleCardView);
         },
 
         showMediaDetail: function (opts) {

--- a/static/apps/presentation/templates/title-card.html
+++ b/static/apps/presentation/templates/title-card.html
@@ -1,6 +1,6 @@
 <div>
     <div class='section'>
-        <h3 class='title-card_header'>{{title}}</h3>
+        <h3 class='title-card_header'>{{header}}</h3>
     </div>
     <div class='section'>
         <div class='carousel'></div>

--- a/static/apps/presentation/views/map-header.js
+++ b/static/apps/presentation/views/map-header.js
@@ -7,9 +7,9 @@ define(["underscore",
         var MapHeader = Marionette.ItemView.extend({
 
             template: Handlebars.compile(
-                '<h1 style="font-weight: {{ fontWeight }}; color: {{ fontColor }}; font-size: {{ fontSize }}; font-family: {{ fontFamily }};">\
+                '<a href=""><h1 style="font-weight: {{ fontWeight }}; color: {{ fontColor }}; font-size: {{ fontSize }}; font-family: {{ fontFamily }};">\
                     {{ name }} \
-                </h1> \
+                </h1> </a>\
                 <h2>{{caption}}</h2> \
             '),
 

--- a/static/apps/presentation/views/title-card.js
+++ b/static/apps/presentation/views/title-card.js
@@ -14,6 +14,7 @@ define(["underscore",
 
             initialize: function (opts) {
                 _.extend(this, opts);
+                console.log(this.model);
             },
 
             renderCarousel: function () {

--- a/static/apps/presentation/views/title-card.js
+++ b/static/apps/presentation/views/title-card.js
@@ -14,7 +14,6 @@ define(["underscore",
 
             initialize: function (opts) {
                 _.extend(this, opts);
-                console.log(this.model);
             },
 
             renderCarousel: function () {


### PR DESCRIPTION
Made it so that if the map metadata attribute 'displayTitleCard' is false, then the title-card will not display in the Presentation App. If it is true, it will display the title card. 

Also, now you can click on the map title in the top left section of the page and it will link you back to the title card, or to a "home" state if there is no title card.

**Two issues:**
1. What happens if the user has 'displayTitleCard' set to true, but they haven't configured it with any information? Should we just show an empty title card? That seems reasonable to me,  but I just want to make sure.

2. I'm noticing a very strange bug where a title-card loses its references to media items that have been attached to it. It happens if you refresh the Main App and then toggle any of the presentation options. So map.get('metadata').titleCardInfo.media is an array with references to media items, and that array will get emptied unintentionally. Let me know if you need help recreating this bug. Might have something to do with the TitleCard model?