### PR TITLE
Truncate titles

### DIFF
--- a/static/apps/main/main-app.js
+++ b/static/apps/main/main-app.js
@@ -70,7 +70,6 @@ define([
             this.listenTo(this.vent, 'show-modal', this.showModal);
             this.listenTo(this.vent, 'hide-modal', this.hideModal);
             this.addMessageListeners();
-            console.log(this);
         },
 
         showDataDetail: function(info) {

--- a/static/apps/main/main-app.js
+++ b/static/apps/main/main-app.js
@@ -70,7 +70,7 @@ define([
             this.listenTo(this.vent, 'show-modal', this.showModal);
             this.listenTo(this.vent, 'hide-modal', this.hideModal);
             this.addMessageListeners();
-
+            console.log(this);
         },
 
         showDataDetail: function(info) {

--- a/static/apps/main/templates/left/map-title.html
+++ b/static/apps/main/templates/left/map-title.html
@@ -2,8 +2,8 @@
 <a href="#" class="map-title">
     <h2>
         {{ name }}
-        <i class="fa fa-pencil-alt right"></i>
     </h2>
+    <i class="fa fa-pencil-alt right"></i>
 </a>
 <a href="#" class="add-layer">
     <i class="fa fa-plus add" aria-hidden="true"></i>

--- a/static/apps/main/views/edit-title-card.js
+++ b/static/apps/main/views/edit-title-card.js
@@ -6,8 +6,9 @@ define([
     "views/add-media",
     "lib/media/photo-video-viewer",
     "lib/media/audio-viewer",
+    "lib/media/edit-media-info",
     "text!../templates/edit-title-card.html"
-], function (_, Handlebars, Marionette, AddMedia, PhotoVideoView, AudioView, EditTitleCardTemplate) {
+], function (_, Handlebars, Marionette, AddMedia, PhotoVideoView, AudioView, EditMediaInfoView, EditTitleCardTemplate) {
     "use strict";
     var EditTitleCard = Marionette.ItemView.extend({
         template: Handlebars.compile(EditTitleCardTemplate),
@@ -60,7 +61,22 @@ define([
         },
 
         editModel: function (model) {
-            alert(model.get('name'));
+            console.log(model);
+            const editMediaInfo = new EditMediaInfoView({
+                app: this.app,
+                model: model
+            });
+
+            this.secondaryModal.update({
+                title: 'Edit Media Info',
+                view: editMediaInfo,
+                width: 700,
+                saveButtonText: "Save",
+                showDeleteButton: false,
+                showSaveButton: true,
+                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
+            });
+            this.secondaryModal.show();
         },
 
         updateMediaOrdering: function (id, overlay_type, newOrder) {
@@ -89,7 +105,7 @@ define([
                 saveButtonText: "Add",
                 showDeleteButton: false,
                 showSaveButton: true,
-                saveFunction: uploadAttachMedia.addModels.bind(uploadAttachMedia),
+                saveFunction: uploadAttachMedia.addModels.bind(uploadAttachMedia)
             });
             this.secondaryModal.show();
             uploadAttachMedia.showUploader();

--- a/static/apps/main/views/edit-title-card.js
+++ b/static/apps/main/views/edit-title-card.js
@@ -43,8 +43,7 @@ define([
                 app: this.app,
                 collection: this.model.getPhotoVideoCollection(this.app.dataManager),
                 detachMediaFunction: this.detachMedia.bind(this),
-                updateOrdering: this.updateMediaOrdering.bind(this),
-                editFunction: this.editModel.bind(this)
+                updateOrdering: this.updateMediaOrdering.bind(this)
             });
             this.$el.find('.title-card_media').append(this.photoVideoView.$el);
         },
@@ -54,29 +53,9 @@ define([
                 app: this.app,
                 collection: this.model.getAudioCollection(this.app.dataManager),
                 detachMediaFunction: this.detachMedia.bind(this),
-                updateOrdering: this.updateMediaOrdering.bind(this),
-                editFunction: this.editModel.bind(this)
+                updateOrdering: this.updateMediaOrdering.bind(this)
             });
             this.$el.find('.title-card_media').append(this.audioView.$el);
-        },
-
-        editModel: function (model) {
-            console.log(model);
-            const editMediaInfo = new EditMediaInfoView({
-                app: this.app,
-                model: model
-            });
-
-            this.secondaryModal.update({
-                title: 'Edit Media Info',
-                view: editMediaInfo,
-                width: 600,
-                saveButtonText: "Save",
-                showDeleteButton: false,
-                showSaveButton: true,
-                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
-            });
-            this.secondaryModal.show();
         },
 
         updateMediaOrdering: function (id, overlay_type, newOrder) {

--- a/static/apps/main/views/edit-title-card.js
+++ b/static/apps/main/views/edit-title-card.js
@@ -6,9 +6,8 @@ define([
     "views/add-media",
     "lib/media/photo-video-viewer",
     "lib/media/audio-viewer",
-    "lib/media/edit-media-info",
     "text!../templates/edit-title-card.html"
-], function (_, Handlebars, Marionette, AddMedia, PhotoVideoView, AudioView, EditMediaInfoView, EditTitleCardTemplate) {
+], function (_, Handlebars, Marionette, AddMedia, PhotoVideoView, AudioView, EditTitleCardTemplate) {
     "use strict";
     var EditTitleCard = Marionette.ItemView.extend({
         template: Handlebars.compile(EditTitleCardTemplate),

--- a/static/apps/main/views/edit-title-card.js
+++ b/static/apps/main/views/edit-title-card.js
@@ -70,7 +70,7 @@ define([
             this.secondaryModal.update({
                 title: 'Edit Media Info',
                 view: editMediaInfo,
-                width: 700,
+                width: 600,
                 saveButtonText: "Save",
                 showDeleteButton: false,
                 showSaveButton: true,

--- a/static/apps/main/views/spreadsheet/spreadsheet.js
+++ b/static/apps/main/views/spreadsheet/spreadsheet.js
@@ -6,11 +6,10 @@ define(["jquery",
         "text!../../templates/spreadsheet/spreadsheet.html",
         "lib/media/audio-viewer",
         "lib/media/photo-video-viewer",
-        "lib/media/edit-media-info",
         "apps/main/views/spreadsheet/context-menu"
     ],
     function ($, Marionette, _, Handlebars, Handsontable, SpreadsheetTemplate,
-            AudioViewer, PhotoVideoViewer, EditMediaInfoView, ContextMenu) {
+            AudioViewer, PhotoVideoViewer, ContextMenu) {
         'use strict';
         var Spreadsheet = Marionette.ItemView.extend({
             /**

--- a/static/apps/main/views/spreadsheet/spreadsheet.js
+++ b/static/apps/main/views/spreadsheet/spreadsheet.js
@@ -6,10 +6,11 @@ define(["jquery",
         "text!../../templates/spreadsheet/spreadsheet.html",
         "lib/media/audio-viewer",
         "lib/media/photo-video-viewer",
+        "lib/media/edit-media-info",
         "apps/main/views/spreadsheet/context-menu"
     ],
     function ($, Marionette, _, Handlebars, Handsontable, SpreadsheetTemplate,
-            AudioViewer, PhotoVideoViewer, ContextMenu) {
+            AudioViewer, PhotoVideoViewer, EditMediaInfoView, ContextMenu) {
         'use strict';
         var Spreadsheet = Marionette.ItemView.extend({
             /**
@@ -30,6 +31,7 @@ define(["jquery",
                 _.extend(this, opts);
                 this.height = this.height || $(window).height() - 170,
                 this.popover = this.app.popover;
+                this.secondaryModal = this.app.secondaryModal;
                 Marionette.ItemView.prototype.initialize.call(this);
                 this.registerRatingEditor();
 
@@ -293,16 +295,13 @@ define(["jquery",
                         app: this.app,
                         collection: model.getPhotoVideoCollection(this.app.dataManager),
                         templateType: 'spreadsheet',
-                        detachMedia: this.detachMediaModel.bind(this),
-                        editFunction: this.editMediaModel.bind(this)
+                        detachMedia: this.detachMediaModel.bind(this)
                     });
                     $(td).append(this.photoVideoViewer.$el);
                 }
                 return td;
             },
-            editMediaModel: function (model) {
-                alert('edit: ' + model.get('name'));
-            },
+            
             detachMediaModel: function (model) {
                 alert('detach: ' + model.get('name'));
             },
@@ -315,8 +314,7 @@ define(["jquery",
                         app: this.app,
                         collection: model.getAudioCollection(this.app.dataManager),
                         templateType: 'spreadsheet',
-                        detachMedia: this.detachMediaModel.bind(this),
-                        editFunction: this.editMediaModel.bind(this)
+                        detachMedia: this.detachMediaModel.bind(this)
                     });
                     $(td).append(this.audioView.$el);
                 }

--- a/static/apps/presentation/templates/title-card.html
+++ b/static/apps/presentation/templates/title-card.html
@@ -3,7 +3,7 @@
         <h3 class='title-card_header'>{{title}}</h3>
     </div>
     <div class='section'>
-        <div class='carousel'></div>
+        <div class='carousel' style="margin-bottom: 40px;"></div>
         <div class='audio-players'></div>
     </div>
     <div class='section'>

--- a/static/apps/presentation/templates/title-card.html
+++ b/static/apps/presentation/templates/title-card.html
@@ -3,10 +3,10 @@
         <h3 class='title-card_header'>{{title}}</h3>
     </div>
     <div class='section'>
-        <div class='carousel' style="margin-bottom: 40px;"></div>
+        <div class='carousel'></div>
         <div class='audio-players'></div>
     </div>
-    <div class='section'>
+    <div class='section' style="margin-top: 40px;">
         <p class='title-card_body'>{{description}}</p>
     </div>
 </div>

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -1833,7 +1833,8 @@ nav li.active {
 }
 
 .edit-media-info img {
-  width: 500px;
+  max-width: 500px;
+  max-height: 500px;
   margin: 0 auto;
   display: block;
 }

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -138,6 +138,9 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
           box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
   display: block;
   background: #354c79;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .map-title h2 {
@@ -146,10 +149,23 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
   font-weight: 400;
   font-size: 18px;
   width: 260px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .map-title h2 .fa {
   display: none;
+}
+
+.map-title .fa {
+  color: #fff;
+  font-size: 18px;
+  -ms-flex-item-align: center;
+      -ms-grid-row-align: center;
+      align-self: center;
+  padding-right: 10px;
+  visibility: hidden;
 }
 
 .map-title:hover {
@@ -157,7 +173,7 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 }
 
 .map-title:hover .fa {
-  display: block;
+  visibility: visible;
 }
 
 .add-layer {
@@ -446,9 +462,14 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 .layer-container .layer-header .layer-name {
   cursor: pointer;
   font-weight: 600;
-  display: inline;
+  display: inline-block;
   font-size: 13px;
   margin-left: 4px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 200px;
+  vertical-align: sub;
 }
 
 .layer-container .layer-header .collapse {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -1834,7 +1834,7 @@ nav li.active {
 
 .edit-media-info img {
   max-width: 500px;
-  max-height: 500px;
+  max-height: 400px;
   margin: 0 auto;
   display: block;
 }

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -2105,7 +2105,6 @@ audio {
 
 .audio-container .play-ctrls .play {
   cursor: pointer;
-  margin: 20px auto;
 }
 
 .audio-container .play-ctrls .play.pause {

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -1833,7 +1833,7 @@ nav li.active {
 }
 
 .edit-media-info img {
-  width: 550px;
+  width: 500px;
   margin: 0 auto;
   display: block;
 }

--- a/static/css/main-new.css
+++ b/static/css/main-new.css
@@ -8,7 +8,7 @@ html, body {
   height: 100%;
   color: #000;
   -webkit-font-smoothing: antialiased;
-  -webkit-tap-highlight-color: transparent;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   margin: 0px;
 }
 
@@ -134,7 +134,8 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 }
 
 .map-title {
-  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 transparent, 0 2px 4px -1px transparent;
+  -webkit-box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
+          box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
   display: block;
   background: #354c79;
 }
@@ -179,6 +180,8 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 .style-main-panel {
   height: calc(100% - 43px);
   top: 43px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   position: absolute;
   width: 100%;
@@ -211,9 +214,12 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 }
 
 .style-guide {
+  display: -ms-grid;
   display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  grid-template-rows: 100px 300px aside, main;
+  -ms-grid-columns: (1fr)[12];
+      grid-template-columns: repeat(12, 1fr);
+  -ms-grid-rows: 100px 300px aside, main;
+      grid-template-rows: 100px 300px aside, main;
   grid-template-rows-padding: 10px;
 }
 
@@ -462,7 +468,6 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 .layer-container .layer-header .layer-menu {
   -webkit-touch-callout: none;
   -webkit-user-select: none;
-  -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
@@ -593,7 +598,8 @@ div::-webkit-scrollbar-thumb, section::-webkit-scrollbar-thumb {
 }
 
 .ind-symbol {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   padding: 0px 32px;
 }
 
@@ -738,24 +744,36 @@ i.fa.fa.fa-question-circle {
 
 .marker-style .form-inline .row {
   position: relative;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: center;
-  align-items: center;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 }
 
 .marker-style .form-inline .row .msv-label {
-  flex: 0 0 85px;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 85px;
+          flex: 0 0 85px;
 }
 
 .marker-style .form-inline .row .stroke-color {
   height: 25px;
-  flex: 0 0 25px;
+  -webkit-box-flex: 0;
+      -ms-flex: 0 0 25px;
+          flex: 0 0 25px;
   border-radius: 5px;
   border: 2px solid rgba(35, 35, 35, 0.15);
 }
 
 .palette-container {
-  flex: 3;
+  -webkit-box-flex: 3;
+      -ms-flex: 3;
+          flex: 3;
 }
 
 .visual-edit {
@@ -775,14 +793,17 @@ i.fa.fa.fa-question-circle {
 
 .palette-wrapper {
   width: 200px;
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   width: 200px;
   position: absolute;
   background-color: white;
   border-radius: 3px;
   border: 1px solid #e4e5eb;
   z-index: 100;
-  box-shadow: 2px 2px 2px 1px rgba(53, 76, 122, 0.06);
+  -webkit-box-shadow: 2px 2px 2px 1px rgba(53, 76, 122, 0.06);
+          box-shadow: 2px 2px 2px 1px rgba(53, 76, 122, 0.06);
   display: none;
   top: 1px;
 }
@@ -792,9 +813,16 @@ i.fa.fa.fa-question-circle {
 }
 
 .example-markers {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-flow: row wrap;
-  justify-content: center;
+  -webkit-box-orient: horizontal;
+  -webkit-box-direction: normal;
+      -ms-flex-flow: row wrap;
+          flex-flow: row wrap;
+  -webkit-box-pack: center;
+      -ms-flex-pack: center;
+          justify-content: center;
 }
 
 .example-marker-wrapper {
@@ -820,7 +848,8 @@ i.fa.fa.fa-question-circle {
   padding: 4px 6px;
   border-radius: 2px;
   font-size: 14px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   width: 100%;
   border: solid 1px #ebecf2;
 }
@@ -859,14 +888,20 @@ i.fa.fa.fa-question-circle {
 }
 
 .style-menu_inner-row {
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
 .style-menu_shape-inner-row {
   margin: 0 auto;
   width: 100%;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-evenly;
+  -webkit-box-pack: space-evenly;
+      -ms-flex-pack: space-evenly;
+          justify-content: space-evenly;
 }
 
 .style-menu_input-descr {
@@ -989,7 +1024,8 @@ i.fa.fa.fa-question-circle {
 .fullScreen .next, .fullScreen .prev {
   height: 100vh;
   top: 0;
-  transform: translateY(48%);
+  -webkit-transform: translateY(48%);
+          transform: translateY(48%);
 }
 
 .fullScreen .photo {
@@ -1001,7 +1037,8 @@ i.fa.fa.fa-question-circle {
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%);
+  -webkit-transform: translate(-50%, -50%);
+          transform: translate(-50%, -50%);
 }
 
 .fullScreen .carousel-caption {
@@ -1050,6 +1087,8 @@ i.fa.fa.fa-question-circle {
 }
 
 .radio-item-wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   padding: 2px 0px;
 }
@@ -1114,8 +1153,12 @@ i.fa.fa.fa-question-circle {
   padding: 6px 6px;
   cursor: default;
   border-bottom: 1px solid #e4e5eb;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: space-between;
+  -webkit-box-pack: justify;
+      -ms-flex-pack: justify;
+          justify-content: space-between;
 }
 
 .presentation-options_list li span {
@@ -1138,8 +1181,12 @@ i.fa.fa.fa-question-circle {
 }
 
 .photo-icon_wrapper {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  justify-content: flex-end;
+  -webkit-box-pack: end;
+      -ms-flex-pack: end;
+          justify-content: flex-end;
 }
 
 .photo-icon_wrapper i {
@@ -1179,9 +1226,13 @@ i.fa.fa.fa-question-circle {
 }
 
 .symbol-entry-header {
+  display: -ms-grid;
   display: grid;
-  grid-template-columns: 27px auto 22px;
-  align-items: center;
+  -ms-grid-columns: 27px auto 22px;
+      grid-template-columns: 27px auto 22px;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
 }
 
 .symbol-entry-header p {
@@ -1194,8 +1245,10 @@ i.fa.fa.fa-question-circle {
 }
 
 .legend-symbol_expanded {
+  display: -ms-grid;
   display: grid;
-  grid-template-columns: auto 22px;
+  -ms-grid-columns: auto 22px;
+      grid-template-columns: auto 22px;
   margin-left: 34px;
 }
 
@@ -1204,8 +1257,10 @@ i.fa.fa.fa-question-circle {
 }
 
 .legend-symbol_collapsed {
+  display: -ms-grid;
   display: grid;
-  grid-template-columns: 36px auto 22px;
+  -ms-grid-columns: 36px auto 22px;
+      grid-template-columns: 36px auto 22px;
   margin-left: 28px;
 }
 
@@ -1227,8 +1282,12 @@ i.fa.fa.fa-question-circle {
 
 .presentation-record_item {
   padding-left: 35px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  align-items: center;
+  -webkit-box-align: center;
+      -ms-flex-align: center;
+          align-items: center;
   cursor: pointer;
 }
 
@@ -1254,7 +1313,8 @@ i.fa.fa.fa-question-circle {
 
 .modal.spreadsheet .content {
   background: #fafafc;
-  transform: none;
+  -webkit-transform: none;
+          transform: none;
   top: auto;
   margin: 40px auto 0 !important;
   padding-bottom: 10px !important;
@@ -1273,8 +1333,11 @@ i.fa.fa.fa-question-circle {
 }
 
 .modal.spreadsheet .content .body .spreadsheet-toolbar {
-  box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
+  -webkit-box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
+          box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
   padding: 0px 20px 10px 20px;
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
   z-index: 3000000000;
   position: relative;
@@ -1310,6 +1373,8 @@ i.fa.fa.fa-question-circle {
 }
 
 .modal.spreadsheet .handsontable .colHeader {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
 }
 
@@ -1431,7 +1496,10 @@ i.fa.fa.fa-question-circle {
   margin: 4px 5px 8px;
   border: 1px solid #e4e5eb;
   border-radius: 2px;
-  flex-direction: column;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
 }
 
 .column .card-img-preview {
@@ -1466,8 +1534,11 @@ i.fa.fa.fa-question-circle {
 }
 
 #gallery-main.container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
 
 #dropzone {
@@ -1618,9 +1689,6 @@ nav li.active {
   margin: 0 2px;
   border: 1px solid #e4e5eb;
   -webkit-transition: background 0.3s linear;
-  -moz-transition: background 0.3s linear;
-  -ms-transition: background 0.3s linear;
-  -o-transition: background 0.3s linear;
   transition: background 0.3s linear;
   line-height: 26px;
   height: 29px;
@@ -1655,7 +1723,7 @@ nav li.active {
 .modal-search-form button {
   outline: none;
   border: none;
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0);
 }
 
 .pull-right {
@@ -1663,8 +1731,11 @@ nav li.active {
 }
 
 #gallery-main.container {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   margin: 0 auto;
   padding: 20px 14px 24px;
 }
@@ -1705,7 +1776,6 @@ nav li.active {
   /* iOS Safari */
   -webkit-user-select: none;
   /* Safari */
-  -khtml-user-select: none;
   /* Konqueror HTML */
   -moz-user-select: none;
   /* Firefox */
@@ -1760,6 +1830,18 @@ nav li.active {
   color: #b94a48;
   margin: 0px 15px;
   font-size: 13px;
+}
+
+.edit-media-info img {
+  width: 550px;
+  margin: 0 auto;
+  display: block;
+}
+
+.edit-media-info .edit-media-info_input {
+  -webkit-box-flex: 8 !important;
+      -ms-flex-positive: 8 !important;
+          flex-grow: 8 !important;
 }
 
 .success-message, .failure-message, .warning-message {
@@ -1839,6 +1921,8 @@ nav li.active {
 
 .add-media-button {
   margin-top: 10px;
+  display: -webkit-inline-box;
+  display: -ms-inline-flexbox;
   display: inline-flex;
 }
 
@@ -2111,7 +2195,10 @@ audio {
 
 .vol {
   margin-top: 10px;
-  user-select: none;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 
 .vol i {
@@ -2253,7 +2340,8 @@ audio {
 }
 
 .breadcrumb {
-  box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 transparent, 0 2px 4px -1px transparent;
+  -webkit-box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
+          box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
   position: absolute;
   width: 100%;
   min-height: 44px;
@@ -2288,7 +2376,8 @@ audio {
 
 .breadcrumb-container .breadcrumb-hover {
   border-radius: 3px;
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
   padding: 5px;
   cursor: pointer;
 }
@@ -2339,7 +2428,7 @@ audio {
   background-color: #4e70d4;
   color: white;
   padding: 0 11px;
-  border: 1px solid transparent;
+  border: 1px solid rgba(0, 0, 0, 0);
 }
 
 .button-secondary {
@@ -2399,7 +2488,6 @@ span.action.rounded:hover, a.action.rounded:hover {
   border-radius: 2px;
   font-size: 14px;
   -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
   box-sizing: border-box;
   margin: 1px;
   width: 100%;
@@ -2454,7 +2542,8 @@ span.action.rounded:hover, a.action.rounded:hover {
 }
 
 .form .row, .form-inline .row {
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
 
 .form .row label:first-child, .form .row p, .form-inline .row label:first-child, .form-inline .row p {
@@ -2518,26 +2607,36 @@ span.action.rounded:hover, a.action.rounded:hover {
 }
 
 .form-inline .row {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
   margin: 8px 0px;
   /* direct descendents inline */
 }
 
 .form-inline .row > label:first-child {
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   /*border: solid 1px #000;*/
 }
 
 .form-inline .row > textarea, .form-inline .row > input[type="text"], .form-inline .row > input[type="number"],
 .form-inline .row > input[type="date"], .form-inline .row > input[type="password"], .form-inline .row > input[type="email"],
 .form-inline .row > select, .form-inline .row > div {
-  flex: 3;
+  -webkit-box-flex: 3;
+      -ms-flex: 3;
+          flex: 3;
 }
 
 .form-inline .row.error div {
+  display: -webkit-box;
+  display: -ms-flexbox;
   display: flex;
-  flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
 
 .form-inline .row.error div p {
@@ -2555,7 +2654,9 @@ span.action.rounded:hover, a.action.rounded:hover {
 .form .row > label:first-child,
 .form .row > p {
   font-weight: 600;
-  flex: 1;
+  -webkit-box-flex: 1;
+      -ms-flex: 1;
+          flex: 1;
   text-align: left;
 }
 
@@ -2578,7 +2679,8 @@ span.action.rounded:hover, a.action.rounded:hover {
 }
 
 .tgl, .tgl:after, .tgl:before, .tgl *, .tgl *:after, .tgl *:before, .tgl + .tgl-btn {
-  box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+          box-sizing: border-box;
 }
 
 .tgl::-moz-selection, .tgl:after::-moz-selection, .tgl:before::-moz-selection, .tgl *::-moz-selection, .tgl *:after::-moz-selection, .tgl *:before::-moz-selection, .tgl + .tgl-btn::-moz-selection {
@@ -2626,12 +2728,14 @@ span.action.rounded:hover, a.action.rounded:hover {
   background: #f0f0f0;
   border-radius: 2em;
   padding: 2px;
+  -webkit-transition: all .4s ease;
   transition: all .4s ease;
 }
 
 .tgl-light + .tgl-btn:after {
   border-radius: 50%;
   background: #fff;
+  -webkit-transition: all .2s ease;
   transition: all .2s ease;
 }
 
@@ -2766,11 +2870,13 @@ span.action.rounded:hover, a.action.rounded:hover {
 .modal .content {
   position: absolute;
   top: 45%;
-  transform: translateY(-50%);
+  -webkit-transform: translateY(-50%);
+          transform: translateY(-50%);
   vertical-align: middle;
   border-radius: 6px;
   background-color: #fefefe;
-  box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.2);
+          box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.2);
   margin: 20px auto 0;
   width: 800px;
   height: auto;
@@ -2930,7 +3036,8 @@ span.action.rounded:hover, a.action.rounded:hover {
 }
 
 .modal .map-input:focus {
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+  -webkit-box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
+          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.3);
   border: 1px solid #4d90fe;
   outline: none;
 }
@@ -2964,13 +3071,14 @@ span.action.rounded:hover, a.action.rounded:hover {
   width: 100%;
   height: 100%;
   overflow: auto;
-  background-color: transparent;
+  background-color: rgba(0, 0, 0, 0);
 }
 
 .link-anchor {
   position: relative;
   width: 0;
   opacity: 0;
+  -webkit-transition: opacity .2s ease-in-out;
   transition: opacity .2s ease-in-out;
 }
 
@@ -3010,7 +3118,8 @@ span.action.rounded:hover, a.action.rounded:hover {
   width: 150px;
   border-radius: 2px;
   /*box-shadow: 0 0 2px rgba(0,0,0,0.4);*/
-  box-shadow: 1px 1px 16px 1px rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 1px 1px 16px 1px rgba(0, 0, 0, 0.2);
+          box-shadow: 1px 1px 16px 1px rgba(0, 0, 0, 0.2);
   padding: 0px 0px 5px 0px;
 }
 
@@ -3145,7 +3254,8 @@ nav.toolbar-main {
   border-bottom: 1px solid #e4e5eb;
   background-color: white;
   width: 100%;
-  box-shadow: 0 2px 1px 1px rgba(53, 76, 122, 0.06);
+  -webkit-box-shadow: 0 2px 1px 1px rgba(53, 76, 122, 0.06);
+          box-shadow: 0 2px 1px 1px rgba(53, 76, 122, 0.06);
   font-size: 14px;
   position: relative;
   z-index: 40;
@@ -3176,7 +3286,7 @@ nav.toolbar-main .nav {
   margin: 0 10px;
   vertical-align: top;
   padding: 0 2px;
-  border-top: solid 2px transparent;
+  border-top: solid 2px rgba(0, 0, 0, 0);
 }
 
 .nav > li:hover {
@@ -3192,7 +3302,8 @@ nav.toolbar-main .nav {
 }
 
 .toolbar-secondary {
-  box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
+  -webkit-box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
+          box-shadow: 0 1px 1px 1px rgba(53, 76, 122, 0.06);
   height: 30px;
   padding: 10px 18px;
   width: calc(100% - 36px);
@@ -3216,3 +3327,4 @@ nav.toolbar-main .nav {
   width: 100vw;
   height: 80px;
 }
+/*# sourceMappingURL=main-new.css.map */

--- a/static/css/scss/components/_layer_list_item.scss
+++ b/static/css/scss/components/_layer_list_item.scss
@@ -76,9 +76,14 @@
         .layer-name {
             cursor: pointer;
             font-weight: 600;
-            display: inline;
+            display: inline-block;
             font-size: 13px;
             margin-left: 4px;
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+            width: 200px;
+            vertical-align: sub;
         }
         .collapse {
             color: #777;
@@ -99,6 +104,10 @@
                 -ms-user-select: none;
                     user-select: none;
         }
+        // .layer-isShowing {
+        //     vertical-align: baseline;
+        //     height: 16px;
+        // }
     }
 
     .no-symbols-found {

--- a/static/css/scss/components/_media_gallery.scss
+++ b/static/css/scss/components/_media_gallery.scss
@@ -312,7 +312,7 @@ nav li.active {
 .edit-media-info {
     img {
         max-width: 500px;
-        max-height: 500px;
+        max-height: 400px;
         margin: 0 auto;
         display: block;
     }

--- a/static/css/scss/components/_media_gallery.scss
+++ b/static/css/scss/components/_media_gallery.scss
@@ -311,7 +311,8 @@ nav li.active {
 
 .edit-media-info {
     img {
-        width: 500px;
+        max-width: 500px;
+        max-height: 500px;
         margin: 0 auto;
         display: block;
     }

--- a/static/css/scss/components/_media_gallery.scss
+++ b/static/css/scss/components/_media_gallery.scss
@@ -308,3 +308,15 @@ nav li.active {
     margin: 0px 15px;
     font-size: 13px;
 }
+
+.edit-media-info {
+    img {
+        width: 550px;
+        margin: 0 auto;
+        display: block;
+    }
+
+    .edit-media-info_input {
+        flex-grow: 8 !important;
+    }
+}

--- a/static/css/scss/components/_media_gallery.scss
+++ b/static/css/scss/components/_media_gallery.scss
@@ -311,7 +311,7 @@ nav li.active {
 
 .edit-media-info {
     img {
-        width: 550px;
+        width: 500px;
         margin: 0 auto;
         display: block;
     }

--- a/static/css/scss/layout/_left_panel.scss
+++ b/static/css/scss/layout/_left_panel.scss
@@ -3,21 +3,32 @@
     box-shadow: 0 4px 5px 0 rgba(0, 0, 0, 0.1), 0 1px 10px 0 rgba(0, 0, 0, 0), 0 2px 4px -1px rgba(0, 0, 0, 0);
     display: block;
     background: $title-color;
+    display: flex;
     h2 {
         padding: 15px 10px;
         color: #fff;
         font-weight: 400;
         font-size: 18px;
         width: 260px;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
         .fa {
             display: none;
         }
+    }
+    .fa {
+        color: #fff;
+        font-size: 18px;
+        align-self: center;
+        padding-right: 10px;
+        visibility: hidden;
     }
 }
 .map-title:hover {
     background: $title-color-hover;
     .fa {
-        display: block;
+        visibility: visible;
     }
 }
 

--- a/static/css/scss/widgets/_audio.scss
+++ b/static/css/scss/widgets/_audio.scss
@@ -20,7 +20,6 @@ audio {
         margin: 20px 0 10px;
         .play {
             cursor: pointer;
-            margin: 20px auto;
         }
         .play.pause {
             width: 10px;

--- a/static/lib/audio/audio-player.js
+++ b/static/lib/audio/audio-player.js
@@ -1,5 +1,10 @@
-define(["underscore", "marionette", "handlebars", "text!../audio/audio-player.html", "lib/handlebars-helpers"],
-    function (_, Marionette, Handlebars, PlayerTemplate) {
+define([
+    "underscore", "marionette", "handlebars",
+    "lib/media/edit-media-info",
+    "text!../audio/audio-player.html", 
+    "lib/handlebars-helpers"
+],
+    function (_, Marionette, Handlebars, EditMediaInfoView, PlayerTemplate) {
         'use strict';
 
         var AudioPlayer = Marionette.ItemView.extend({
@@ -25,6 +30,7 @@ define(["underscore", "marionette", "handlebars", "text!../audio/audio-player.ht
                 //this.detachMedia = this.detachMedia || (() => {});
                 this.render();
                 this.audio = this.$el.find(".audio").get(0);
+                this.secondaryModal = this.app.secondaryModal;
                 this.listenTo(this.app.vent, 'audio-carousel-advanced', this.stop);
 
                 // need to attach audio events directly to the element b/c the
@@ -45,12 +51,23 @@ define(["underscore", "marionette", "handlebars", "text!../audio/audio-player.ht
                 }
             },
             edit: function (e) {
-                // editFunction passed in via constructor:
-                if (this.editFunction) {
                     const audioID = parseInt($(e.target).attr('data-id'));
                     const audioModel = this.app.dataManager.getAudio(audioID);
-                    this.editFunction(audioModel);
-                }
+                    const editMediaInfo = new EditMediaInfoView({
+                        app: this.app,
+                        model: audioModel
+                    });
+        
+                    this.secondaryModal.update({
+                        title: 'Edit Media Info',
+                        view: editMediaInfo,
+                        width: 600,
+                        saveButtonText: "Save",
+                        showDeleteButton: false,
+                        showSaveButton: true,
+                        saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
+                    });
+                    this.secondaryModal.show();
             },
             onRender: function () {
                 if (!this.$el.find('.progress-container').get(0)) {

--- a/static/lib/audio/audio-player.js
+++ b/static/lib/audio/audio-player.js
@@ -1,10 +1,9 @@
 define([
     "underscore", "marionette", "handlebars",
-    "lib/media/edit-media-info",
     "text!../audio/audio-player.html", 
     "lib/handlebars-helpers"
 ],
-    function (_, Marionette, Handlebars, EditMediaInfoView, PlayerTemplate) {
+    function (_, Marionette, Handlebars, PlayerTemplate) {
         'use strict';
 
         var AudioPlayer = Marionette.ItemView.extend({
@@ -53,21 +52,7 @@ define([
             edit: function (e) {
                     const audioID = parseInt($(e.target).attr('data-id'));
                     const audioModel = this.app.dataManager.getAudio(audioID);
-                    const editMediaInfo = new EditMediaInfoView({
-                        app: this.app,
-                        model: audioModel
-                    });
-        
-                    this.secondaryModal.update({
-                        title: 'Edit Media Info',
-                        view: editMediaInfo,
-                        width: 600,
-                        saveButtonText: "Save",
-                        showDeleteButton: false,
-                        showSaveButton: true,
-                        saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
-                    });
-                    this.secondaryModal.show();
+                    this.editAudio(audioModel);
             },
             onRender: function () {
                 if (!this.$el.find('.progress-container').get(0)) {

--- a/static/lib/forms/backbone-form-editors.js
+++ b/static/lib/forms/backbone-form-editors.js
@@ -228,7 +228,12 @@ define([
                 model: model
             });
 
-            this.app.modal.update({
+            // use the secondaryModal because in the other place where we use 
+            // the editMediaInfo view, we insert into the secondaryModal due to the fact
+            // that the primary modal is already in use. So we also use the secondary 
+            // modal here just to be consistent. Otherwise we encounter issues
+            // when trying to close the modal upon save.
+            this.app.secondaryModal.update({
                 title: 'Edit Media Info',
                 view: editMediaInfo,
                 width: 600,
@@ -238,7 +243,7 @@ define([
                 saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
             });
             console.log(this.app);
-            this.app.modal.show();
+            this.app.secondaryModal.show();
         },
         showMediaBrowser: function (e) {
             var addMediaLayoutView = new AddMedia({

--- a/static/lib/forms/backbone-form-editors.js
+++ b/static/lib/forms/backbone-form-editors.js
@@ -8,14 +8,13 @@ define([
     "lib/media/photo-video-viewer",
     "lib/media/audio-viewer",
     "lib/audio/audio-player",
-    "lib/media/edit-media-info",
     "external/pikaday-forked",
     "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.28.5/date_fns.min.js",
     "text!../forms/templates/date-time-template.html",
     "text!../forms/templates/media-editor-template.html",
     "form"
 ], function ($, Backbone, Handlebars, Association, Audio, AddMedia,
-            PhotoVideoView, AudioView, AudioPlayer, EditMediaInfoView, Pikaday, dateFns,
+            PhotoVideoView, AudioView, AudioPlayer, Pikaday, dateFns,
             DateTimeTemplate, MediaTemplate) {
     "use strict";
 

--- a/static/lib/forms/backbone-form-editors.js
+++ b/static/lib/forms/backbone-form-editors.js
@@ -242,7 +242,6 @@ define([
                 showSaveButton: true,
                 saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
             });
-            console.log(this.app);
             this.app.secondaryModal.show();
         },
         showMediaBrowser: function (e) {

--- a/static/lib/forms/backbone-form-editors.js
+++ b/static/lib/forms/backbone-form-editors.js
@@ -222,28 +222,7 @@ define([
                 this.refreshWidgetFromDatabase.bind(this)
             );
         },
-        editModel: function (model) {
-            const editMediaInfo = new EditMediaInfoView({
-                app: this.app,
-                model: model
-            });
-
-            // use the secondaryModal because in the other place where we use 
-            // the editMediaInfo view, we insert into the secondaryModal due to the fact
-            // that the primary modal is already in use. So we also use the secondary 
-            // modal here just to be consistent. Otherwise we encounter issues
-            // when trying to close the modal upon save.
-            this.app.secondaryModal.update({
-                title: 'Edit Media Info',
-                view: editMediaInfo,
-                width: 600,
-                saveButtonText: "Save",
-                showDeleteButton: false,
-                showSaveButton: true,
-                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
-            });
-            this.app.secondaryModal.show();
-        },
+        
         showMediaBrowser: function (e) {
             var addMediaLayoutView = new AddMedia({
                 app: this.app,
@@ -277,7 +256,6 @@ define([
         attachPhotoVideoView: function () {
             this.photoVideoView = new PhotoVideoView({
                 detachMediaFunction: this.detachModel.bind(this),
-                editFunction: this.editModel.bind(this),
                 app: this.app,
                 showStars: true,
                 recordModel: this.model,
@@ -290,7 +268,6 @@ define([
         attachAudioView: function () {
             this.audioView = new AudioView({
                 detachMediaFunction: this.detachModel.bind(this),
-                editFunction: this.editModel.bind(this),
                 app: this.app,
                 collection: this.model.getAudioCollection(this.app.dataManager),
                 updateOrdering: this.updateOrdering.bind(this)

--- a/static/lib/forms/backbone-form-editors.js
+++ b/static/lib/forms/backbone-form-editors.js
@@ -8,13 +8,14 @@ define([
     "lib/media/photo-video-viewer",
     "lib/media/audio-viewer",
     "lib/audio/audio-player",
+    "lib/media/edit-media-info",
     "external/pikaday-forked",
     "https://cdnjs.cloudflare.com/ajax/libs/date-fns/1.28.5/date_fns.min.js",
     "text!../forms/templates/date-time-template.html",
     "text!../forms/templates/media-editor-template.html",
     "form"
 ], function ($, Backbone, Handlebars, Association, Audio, AddMedia,
-            PhotoVideoView, AudioView, AudioPlayer, Pikaday, dateFns,
+            PhotoVideoView, AudioView, AudioPlayer, EditMediaInfoView, Pikaday, dateFns,
             DateTimeTemplate, MediaTemplate) {
     "use strict";
 
@@ -222,7 +223,22 @@ define([
             );
         },
         editModel: function (model) {
-            alert(model.get('name'));
+            const editMediaInfo = new EditMediaInfoView({
+                app: this.app,
+                model: model
+            });
+
+            this.app.modal.update({
+                title: 'Edit Media Info',
+                view: editMediaInfo,
+                width: 600,
+                saveButtonText: "Save",
+                showDeleteButton: false,
+                showSaveButton: true,
+                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
+            });
+            console.log(this.app);
+            this.app.modal.show();
         },
         showMediaBrowser: function (e) {
             var addMediaLayoutView = new AddMedia({

--- a/static/lib/media/audio-viewer.js
+++ b/static/lib/media/audio-viewer.js
@@ -19,7 +19,7 @@ define([
         //     'click .edit': 'editAudioFile'
         // },
         //className: 'media-items_wrapper',
-        //className: 'media-items_wrapper',
+        className: 'media-items_wrapper',
         templateHelpers: function () {
             const showHeader = this.collection.length > 0 && this.templateType === 'standard';
             return {

--- a/static/lib/media/audio-viewer.js
+++ b/static/lib/media/audio-viewer.js
@@ -4,14 +4,16 @@ define([
     "handlebars",
     "marionette",
     "lib/audio/audio-player",
+    "lib/media/edit-media-info",
     "text!./audio-viewer.html"
-], function (_, Handlebars, Marionette, AudioPlayer, AudioViewerTemplate) {
+], function (_, Handlebars, Marionette, AudioPlayer, EditMediaInfoView, AudioViewerTemplate) {
     "use strict";
     var AudioViewer = Marionette.ItemView.extend({
         template: Handlebars.compile(AudioViewerTemplate),
         initialize: function (opts) {
             _.extend(this, opts);
             this.templateType = this.templateType || 'standard';
+            this.secondaryModal = this.app.secondaryModal;
             this.render();
         },
         // events: {
@@ -35,7 +37,8 @@ define([
         renderAudioPlayers: function () {
             const opts = {
                 audioMode: "basic",
-                app: this.app
+                app: this.app,
+                editAudio: this.editAudio.bind(this)
             }
             if (this.editFunction) {
                 opts.editFunction = this.editFunction.bind(this);
@@ -49,6 +52,25 @@ define([
                 this.$el.append(player.$el);
             });
         },
+
+        editAudio: function (audioModel) {
+            const editMediaInfo = new EditMediaInfoView({
+                app: this.app,
+                model: audioModel
+            });
+
+            this.secondaryModal.update({
+                title: 'Edit Media Info',
+                view: editMediaInfo,
+                width: 600,
+                saveButtonText: "Save",
+                showDeleteButton: false,
+                showSaveButton: true,
+                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
+            });
+            this.secondaryModal.show();
+        },
+
         enableMediaReordering: function () {
             if (this.updateOrdering) {
                 this.$el.sortable({

--- a/static/lib/media/edit-media-info.html
+++ b/static/lib/media/edit-media-info.html
@@ -21,6 +21,13 @@
     {{/ifequal}}
 {{/ifequal}}
 
+{{#ifequal overlay_type 'audio' }}
+    <div class="edit-audio">
+
+    </div>
+{{/ifequal}}
+
+
 
 <form class="form-inline">
     <div class="row">

--- a/static/lib/media/edit-media-info.html
+++ b/static/lib/media/edit-media-info.html
@@ -1,8 +1,31 @@
-<img src="{{this.path_large}}"></img>
+{{#ifequal overlay_type 'photo' }}
+    <img src="{{path_large}}"></img>
+{{/ifequal}}
+
+{{#ifequal overlay_type 'video' }}
+    {{#ifequal video_provider "vimeo"}}
+        <iframe class="photo" src="https://player.vimeo.com/video/{{video_id}}"
+        style="margin: 0 auto;
+        display: block;" height="200"
+        frameborder="0"
+        webkitallowfullscreen mozallowfullscreen allowfullscreen>
+        </iframe>
+    {{/ifequal}}
+
+    {{#ifequal video_provider "youtube"}}
+        <iframe class="photo" src="https://www.youtube.com/embed/{{video_id}}?ecver=1"
+        style="margin: 0 auto;
+        display: block;" height="200"
+        frameborder="0" allowfullscreen>
+        </iframe>
+    {{/ifequal}}
+{{/ifequal}}
+
+
 <form class="form-inline">
     <div class="row">
         <label>Author:</label>
-        <input id="media-attribution" class="edit-media-info_input" type="text" value="{{author}}">
+        <input id="media-attribution" class="edit-media-info_input" type="text" value="{{attribution}}">
     </div>
     <div class="row">
         <label>Name:</label>

--- a/static/lib/media/edit-media-info.html
+++ b/static/lib/media/edit-media-info.html
@@ -1,0 +1,15 @@
+<img src="{{this.path_large}}"></img>
+<form class="form-inline">
+    <div class="row">
+        <label>Author:</label>
+        <input id="media-attribution" class="edit-media-info_input" type="text" value="{{author}}">
+    </div>
+    <div class="row">
+        <label>Name:</label>
+        <input id="media-name" class="edit-media-info_input" type="text" value="{{name}}">
+    </div>
+    <div class="row">
+        <label>Caption:</label>
+        <input id="media-caption" class="edit-media-info_input" type="text" value="{{caption}}">
+    </div>
+</form>

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -11,6 +11,7 @@ define([
         initialize: function (opts) {
             _.extend(this, opts);
             this.secondaryModal = this.app.secondaryModal;
+            console.trace();
             console.log(this.model);
         },
         

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -11,8 +11,6 @@ define([
         initialize: function (opts) {
             _.extend(this, opts);
             this.secondaryModal = this.app.secondaryModal;
-            console.trace();
-            console.log(this.model);
         },
         
         className: 'edit-media-info',
@@ -21,13 +19,11 @@ define([
             this.model.set('attribution', this.$el.find('#media-attribution').val());
             this.model.set('name', this.$el.find('#media-name').val());
             this.model.set('caption', this.$el.find('#media-caption').val());
-            console.log(this);
             this.model.save(null, {
                 success: () => {
                     this.secondaryModal.hide();
                 }
             });
-            //this.render();
         }
     });
     return EditMediaInfo;

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -11,17 +11,10 @@ define([
         initialize: function (opts) {
             _.extend(this, opts);
             this.secondaryModal = this.app.secondaryModal;
+            console.log(this.model);
         },
         
         className: 'edit-media-info',
-
-        templateHelpers: function () {
-            return {
-                author: this.model.get('attribution'),
-                caption: this.model.get('caption'),
-                name: this.model.get('name')
-            };
-        },
 
         saveMediaInfo: function () {
             this.model.set('attribution', this.$el.find('#media-attribution').val());

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -3,8 +3,9 @@ define([
     "underscore",
     "handlebars",
     "marionette",
+    "lib/audio/audio-player",
     "text!./edit-media-info.html"
-], function (_, Handlebars, Marionette, EditMediaInfoTemplate) {
+], function (_, Handlebars, Marionette, AudioPlayer, EditMediaInfoTemplate) {
     "use strict";
     var EditMediaInfo = Marionette.ItemView.extend({
         template: Handlebars.compile(EditMediaInfoTemplate),
@@ -14,6 +15,19 @@ define([
         },
         
         className: 'edit-media-info',
+
+        onRender: function() {
+            if (this.model.get('overlay_type') === 'audio') {
+                this.audioPlayer = new AudioPlayer({
+                    model: this.model,
+                    app: this.app,
+                    panelStyles: this.panelStyles,
+                    audioMode: "detail",
+                    className: "audio-detail"
+                });
+                this.$el.find(".edit-audio").append(this.audioPlayer.$el);
+            }
+        },
 
         saveMediaInfo: function () {
             this.model.set('attribution', this.$el.find('#media-attribution').val());

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -21,9 +21,13 @@ define([
             this.model.set('attribution', this.$el.find('#media-attribution').val());
             this.model.set('name', this.$el.find('#media-name').val());
             this.model.set('caption', this.$el.find('#media-caption').val());
-            
-            this.model.save();
-            this.render();
+            console.log(this);
+            this.model.save(null, {
+                success: () => {
+                    this.secondaryModal.hide();
+                }
+            });
+            //this.render();
         }
     });
     return EditMediaInfo;

--- a/static/lib/media/edit-media-info.js
+++ b/static/lib/media/edit-media-info.js
@@ -1,0 +1,36 @@
+
+define([
+    "underscore",
+    "handlebars",
+    "marionette",
+    "text!./edit-media-info.html"
+], function (_, Handlebars, Marionette, EditMediaInfoTemplate) {
+    "use strict";
+    var EditMediaInfo = Marionette.ItemView.extend({
+        template: Handlebars.compile(EditMediaInfoTemplate),
+        initialize: function (opts) {
+            _.extend(this, opts);
+            this.secondaryModal = this.app.secondaryModal;
+        },
+        
+        className: 'edit-media-info',
+
+        templateHelpers: function () {
+            return {
+                author: this.model.get('attribution'),
+                caption: this.model.get('caption'),
+                name: this.model.get('name')
+            };
+        },
+
+        saveMediaInfo: function () {
+            this.model.set('attribution', this.$el.find('#media-attribution').val());
+            this.model.set('name', this.$el.find('#media-name').val());
+            this.model.set('caption', this.$el.find('#media-caption').val());
+            
+            this.model.save();
+            this.render();
+        }
+    });
+    return EditMediaInfo;
+});

--- a/static/lib/media/photo-video-viewer.js
+++ b/static/lib/media/photo-video-viewer.js
@@ -4,13 +4,15 @@ define([
     "handlebars",
     "marionette",
     "lib/modals/modal",
+    "lib/media/edit-media-info",
     "text!./photo-video-viewer.html"
-], function (_, Handlebars, Marionette, Modal, PhotoVideoTemplate) {
+], function (_, Handlebars, Marionette, Modal, EditMediaInfoView, PhotoVideoTemplate) {
     "use strict";
     var PhotoVideoViewer = Marionette.ItemView.extend({
         template: Handlebars.compile(PhotoVideoTemplate),
         initialize: function (opts) {
             _.extend(this, opts);
+            this.secondaryModal = this.app.secondaryModal;
             this.render();
         },
         events: {
@@ -39,14 +41,26 @@ define([
             }
         },
         edit: function (e) {
-            // editFunction passed in via constructor:
-            if (this.editFunction) {
-                const $elem = $(e.target);
-                const attachmentType = $elem.attr("data-type") + 's';
-                const id = parseInt($elem.attr("data-id"));
-                const model = this.app.dataManager.getCollection(attachmentType).get(id);
-                this.editFunction(model);
-            }
+            const $elem = $(e.target);
+            const attachmentType = $elem.attr("data-type") + 's';
+            const id = parseInt($elem.attr("data-id"));
+            const model = this.app.dataManager.getCollection(attachmentType).get(id);
+
+            const editMediaInfo = new EditMediaInfoView({
+                app: this.app,
+                model: model
+            });
+
+            this.secondaryModal.update({
+                title: 'Edit Media Info',
+                view: editMediaInfo,
+                width: 600,
+                saveButtonText: "Save",
+                showDeleteButton: false,
+                showSaveButton: true,
+                saveFunction: editMediaInfo.saveMediaInfo.bind(editMediaInfo)
+            });
+            this.secondaryModal.show(); 
         },
         onRender: function () {
             this.enableMediaReordering();

--- a/static/tests/spec-runner1.js
+++ b/static/tests/spec-runner1.js
@@ -53,6 +53,7 @@ require(['boot'], function () {
         'spec/lib/carousel-test.js',
         'spec/sql-parser-test.js',
         'spec/truth-statement-test.js',
+        'spec/lib/edit-media-info-test.js',
 
         // models
         'spec/models/layer-test.js',

--- a/static/tests/spec/lib/edit-media-info-test.js
+++ b/static/tests/spec/lib/edit-media-info-test.js
@@ -5,7 +5,7 @@ define([
 ],
     function (Backbone, EditMediaInfo) {
         'use strict';
-        const initEditMediaInfo = function (scope) {
+        const initEditMediaInfo = function (scope, mediaType) {
 
             // 1) add spies for all relevant objects:
             spyOn(EditMediaInfo.prototype, 'initialize').and.callThrough();
@@ -17,17 +17,27 @@ define([
             scope.fixture = setFixtures('<div></div>');
 
             // 3) initialize view:
-            const photo = scope.app.dataManager.getCollection('photos').get(20);
+            let mediaModel;
+            if (mediaType === 'photos') {
+                mediaModel = scope.app.dataManager.getCollection('photos').get(20);
+            } else if (mediaType === 'videos') {
+                mediaModel = scope.app.dataManager.getCollection('videos').get(50);
+            } else if (mediaType === 'audio') {
+                mediaModel = scope.app.dataManager.getCollection('audio').get(3);
+            } else {
+                mediaModel = scope.app.dataManager.getCollection('photos').get(20);
+            }
+             
             scope.editMediaInfo = new EditMediaInfo({
                 app: scope.app,
-                model: photo
+                model: mediaModel
             });
             scope.editMediaInfo.render();
         };
 
-        describe('EditMediaInfo', function () {
+        describe('EditMediaInfo (with photo)', function () {
             beforeEach(function () {
-                initEditMediaInfo(this);
+                initEditMediaInfo(this, 'photo');
             });
 
             it('initialize works', function() {
@@ -44,6 +54,15 @@ define([
                 expect(this.editMediaInfo.$el.find('#media-caption').val()).toEqual('');
                 expect(this.editMediaInfo.$el.find('#media-name').val()).toEqual('DSC04705.JPG');
             });
+
+            it('renders photos properly', function() {
+                expect(this.editMediaInfo.$el).toContainElement('img');
+                expect(this.editMediaInfo.$el).not.toContainElement('iframe');
+                expect(this.editMediaInfo.$el).not.toContainElement('.edit-audio');
+                expect(this.editMediaInfo.$el.find('img')[0].src).toEqual(
+                    this.editMediaInfo.model.get('path_large')
+                );
+            });
             
             it('saveMediaInfo() works', function() {
                 this.editMediaInfo.$el.find('#media-attribution').val('George Washington');
@@ -59,6 +78,65 @@ define([
                 expect(this.editMediaInfo.model.get('attribution')).toEqual('George Washington');
                 expect(this.editMediaInfo.model.get('caption')).toEqual('photo of building');
                 expect(this.editMediaInfo.model.get('name')).toEqual('building');
+            });
+        });
+        describe('EditMediaInfo (with video)', function () {
+            beforeEach(function () {
+                initEditMediaInfo(this, 'videos');
+            });
+
+            it('initialize works', function() {
+                expect(this.editMediaInfo).toEqual(jasmine.any(EditMediaInfo));
+                expect(this.editMediaInfo.model.id).toEqual(50);
+            });
+
+            it('renders correct info', function() {
+                expect(this.editMediaInfo.model.get('attribution')).toEqual(null);
+                expect(this.editMediaInfo.model.get('caption')).toEqual(null);
+                expect(this.editMediaInfo.model.get('name')).toEqual('Untitled');
+
+                expect(this.editMediaInfo.$el.find('#media-attribution').val()).toEqual('');
+                expect(this.editMediaInfo.$el.find('#media-caption').val()).toEqual('');
+                expect(this.editMediaInfo.$el.find('#media-name').val()).toEqual('Untitled');
+            });
+
+            it('renders photos properly', function() {
+                expect(this.editMediaInfo.$el).toContainElement('iframe');
+                expect(this.editMediaInfo.$el).not.toContainElement('img');
+                expect(this.editMediaInfo.$el).not.toContainElement('.edit-audio');
+                expect(this.editMediaInfo.$el.find('iframe')[0].src).toEqual(
+                    `https://www.youtube.com/embed/${this.editMediaInfo.model.get('video_id')}?ecver=1`
+                );
+            });
+        });
+        describe('EditMediaInfo (with audio)', function () {
+            beforeEach(function () {
+                initEditMediaInfo(this, 'audio');
+            });
+
+            it('initialize works', function() {
+                expect(this.editMediaInfo).toEqual(jasmine.any(EditMediaInfo));
+                expect(this.editMediaInfo.model.id).toEqual(3);
+            });
+
+            it('renders correct info', function() {
+                expect(this.editMediaInfo.model.get('attribution')).toEqual('vanwars');
+                expect(this.editMediaInfo.model.get('caption')).toEqual(null);
+                expect(this.editMediaInfo.model.get('name')).toEqual('tmpvpqx0b.mp3');
+
+                expect(this.editMediaInfo.$el.find('#media-attribution').val()).toEqual('vanwars');
+                expect(this.editMediaInfo.$el.find('#media-caption').val()).toEqual('');
+                expect(this.editMediaInfo.$el.find('#media-name').val()).toEqual('tmpvpqx0b.mp3');
+            });
+
+            it('renders photos properly', function() {
+                expect(this.editMediaInfo.$el).toContainElement('.edit-audio');
+                expect(this.editMediaInfo.$el).not.toContainElement('iframe');
+                expect(this.editMediaInfo.$el).not.toContainElement('img');
+                
+                expect(this.editMediaInfo.$el.find('source')[0].src).toEqual(
+                    this.editMediaInfo.model.get('file_path')
+                );
             });
         });
     });

--- a/static/tests/spec/lib/edit-media-info-test.js
+++ b/static/tests/spec/lib/edit-media-info-test.js
@@ -1,0 +1,64 @@
+var rootDir = "../../";
+define([
+    "backbone",
+    rootDir + "lib/media/edit-media-info",
+],
+    function (Backbone, EditMediaInfo) {
+        'use strict';
+        const initEditMediaInfo = function (scope) {
+
+            // 1) add spies for all relevant objects:
+            spyOn(EditMediaInfo.prototype, 'initialize').and.callThrough();
+            spyOn(EditMediaInfo.prototype, 'render').and.callThrough();
+
+            //spyOn(Map.prototype, 'save');
+
+            // 2) add dummy HTML elements:
+            scope.fixture = setFixtures('<div></div>');
+
+            // 3) initialize view:
+            const photo = scope.app.dataManager.getCollection('photos').get(20);
+            scope.editMediaInfo = new EditMediaInfo({
+                app: scope.app,
+                model: photo
+            });
+            scope.editMediaInfo.render();
+        };
+
+        describe('EditMediaInfo', function () {
+            beforeEach(function () {
+                initEditMediaInfo(this);
+            });
+
+            it('initialize works', function() {
+                expect(this.editMediaInfo).toEqual(jasmine.any(EditMediaInfo));
+                expect(this.editMediaInfo.model.id).toEqual(20);
+            });
+
+            it('renders correct info', function() {
+                expect(this.editMediaInfo.model.get('attribution')).toEqual('riley');
+                expect(this.editMediaInfo.model.get('caption')).toEqual(null);
+                expect(this.editMediaInfo.model.get('name')).toEqual('DSC04705.JPG');
+
+                expect(this.editMediaInfo.$el.find('#media-attribution').val()).toEqual('riley');
+                expect(this.editMediaInfo.$el.find('#media-caption').val()).toEqual('');
+                expect(this.editMediaInfo.$el.find('#media-name').val()).toEqual('DSC04705.JPG');
+            });
+            
+            it('saveMediaInfo() works', function() {
+                this.editMediaInfo.$el.find('#media-attribution').val('George Washington');
+                this.editMediaInfo.$el.find('#media-caption').val('photo of building');
+                this.editMediaInfo.$el.find('#media-name').val('building');
+
+                expect(this.editMediaInfo.model.get('attribution')).toEqual('riley');
+                expect(this.editMediaInfo.model.get('caption')).toEqual(null);
+                expect(this.editMediaInfo.model.get('name')).toEqual('DSC04705.JPG');
+
+                this.editMediaInfo.saveMediaInfo();
+
+                expect(this.editMediaInfo.model.get('attribution')).toEqual('George Washington');
+                expect(this.editMediaInfo.model.get('caption')).toEqual('photo of building');
+                expect(this.editMediaInfo.model.get('name')).toEqual('building');
+            });
+        });
+    });


### PR DESCRIPTION
Added title truncation for map titles and layer titles. Was a little more complicated than expected due to the inline icons that accompany the titles.

<img width="371" alt="screen shot 2018-08-29 at 11 03 47 am" src="https://user-images.githubusercontent.com/20868615/44807061-7101b880-ab7d-11e8-8d45-db387c9dfcff.png">


I also added truncation to the breadcrumb map title.

**before**
<img width="657" alt="screen shot 2018-08-29 at 11 19 55 am" src="https://user-images.githubusercontent.com/20868615/44807705-14070200-ab7f-11e8-9831-aab88a1ed330.png">


**after**
<img width="597" alt="screen shot 2018-08-29 at 11 27 51 am" src="https://user-images.githubusercontent.com/20868615/44807718-1a957980-ab7f-11e8-80e0-bbcacbc58e88.png">


