### PR TITLE
Legend extents

### DIFF
--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -159,7 +159,7 @@ define(["marionette",
                 this.render();
             },
 
-            // only center the activeOverlay if it is outside the current boundaries of the map
+            // only center the active overlay if it is outside the current boundaries of the map
             centerIfOutsideMapBounds: function(overlay) {
                 if (!this.app.map.getBounds().contains(overlay.getCenter())) {
                     overlay.centerOn();

--- a/static/apps/main/views/left/symbol-item-view.js
+++ b/static/apps/main/views/left/symbol-item-view.js
@@ -154,8 +154,16 @@ define(["marionette",
                 this.active = true;
                 if (this.overlay != null) {
                     this.overlay.activate();
+                    this.centerIfOutsideMapBounds(this.overlay);
                 }
                 this.render();
+            },
+
+            // only center the activeOverlay if it is outside the current boundaries of the map
+            centerIfOutsideMapBounds: function(overlay) {
+                if (!this.app.map.getBounds().contains(overlay.getCenter())) {
+                    overlay.centerOn();
+                }
             },
 
             // this function only does something when adding or deleting entire markers:

--- a/static/apps/presentation/views/legend-symbol-entry.js
+++ b/static/apps/presentation/views/legend-symbol-entry.js
@@ -205,9 +205,16 @@ define(['marionette',
                         }
                         this.app.activeMapMarker = mapMarkerView;
                         mapMarkerView.activate();
+                        this.centerIfOutsideMapBounds(mapMarkerView);
                     }
                 });
-            }
+            },
+            // only center the activeOverlay if it is outside the current boundaries of the map
+            centerIfOutsideMapBounds: function(overlay) {
+                if (!this.app.map.getBounds().contains(overlay.getCenter())) {
+                    overlay.centerOn();
+                }
+            },
         });
         return LegendSymbolEntry;
     });


### PR DESCRIPTION
This PR makes it so that if the user clicks on a record in the legend, its associated map marker will be centered if it is outside the current boundaries of the map (i.e. if it is not currently visible). If it is already within the current boundaries of the map, then nothing will happen.